### PR TITLE
fixed wrong return type of Date Column

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crate
 Unreleased
 ==========
 
+ - Fix: Date columns return date objects
+
 2013/11/25 0.1.7
 ================
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -38,3 +38,7 @@ available in `$PATH`. To run against a single interpreter tox can also be
 invoked like this::
 
     ./bin/tox -e py33
+
+Note: Before running tests make sure to stop all crate instances which
+transport port is listening on port 9300 to avoid side effects with the test
+layer.

--- a/src/crate/client/sqlalchemy/dialect.py
+++ b/src/crate/client/sqlalchemy/dialect.py
@@ -26,7 +26,7 @@ class Date(sqltypes.Date):
             if not value:
                 return
             try:
-                return datetime.utcfromtimestamp(value / 1e3)
+                return datetime.utcfromtimestamp(value / 1e3).date()
             except TypeError:
                 pass
 
@@ -40,9 +40,10 @@ class Date(sqltypes.Date):
                 "Received timestamp isn't a long value."
                 "Trying to parse as date string and then as datetime string")
             try:
-                return datetime.strptime(value, '%Y-%m-%d')
+                return datetime.strptime(value, '%Y-%m-%d').date()
             except ValueError:
-                return datetime.strptime(value, '%Y-%m-%dT%H:%M:%S.%fZ')
+                return datetime.strptime(value,
+                                         '%Y-%m-%dT%H:%M:%S.%fZ').date()
         return process
 
 

--- a/src/crate/client/sqlalchemy/itests.txt
+++ b/src/crate/client/sqlalchemy/itests.txt
@@ -83,6 +83,14 @@ Date should have been set at the insert due to default value via python method::
     >>> (now - location.datetime).seconds < 4
     True
 
+Verify the return type of date and datetime::
+
+    >>> type(location.date)
+    <type 'datetime.date'>
+
+    >>> type(location.datetime)
+    <type 'datetime.datetime'>
+
 the location also has a date and datetime property which both are nullable and
 aren't set when the row is inserted as there is no default method::
 


### PR DESCRIPTION
- Date columns must return objects of type <datetime.date>
- added note to DEVELOP.rst to avoid problems with running crate instances when running tests
