### PR TITLE
remove the '-f' option in the crate test layer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for crate
 Unreleased
 ==========
 
+ - updated crate to 0.27.0 and changed the test layer to no longer use the `-f`
+   option. Note that this breaks the test layer for all previous crate
+   versions.
+
 2014/03/05 0.3.4
 ================
 

--- a/src/crate/testing/layer.py
+++ b/src/crate/testing/layer.py
@@ -40,7 +40,6 @@ class CrateLayer(server.ServerLayer, layer.WorkDirectoryLayer):
             crate_config = os.path.join(crate_home, 'config', 'crate.yml')
         start_cmd = (
             crate_exec,
-            '-f',
             '-Des.index.storage.type=memory',
             '-Des.node.name=%s' % name,
             '-Des.cluster.name=Testing%s' % port,

--- a/versions.cfg
+++ b/versions.cfg
@@ -5,10 +5,9 @@ zc.recipe.testrunner = 2.0.0
 requests = 2.0.1
 setuptools = 1.1
 lovely.testlayers = 0.6.0
-crate_server = 0.26.0
+crate_server = 0.27.0
 
 hexagonit.recipe.download = 1.7
-lovely.buildouthttp = 0.5.0
 
 # Required by:
 # zope.testrunner==4.4.1


### PR DESCRIPTION
(in crate 0.27.0 starting crate in the foreground is now the default)
