### PR TITLE
Fixed multi-engine issue.

### DIFF
--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -73,7 +73,8 @@ def rewrite_update(clauseelement, multiparams, params):
 
 @sa.event.listens_for(sa.engine.Engine, "before_execute", retval=True)
 def crate_before_execute(conn, clauseelement, multiparams, params):
-    if isinstance(clauseelement, sa.sql.expression.Update):
+    is_crate = type(conn.dialect).__name__ == 'CrateDialect'
+    if is_crate and isinstance(clauseelement, sa.sql.expression.Update):
         return rewrite_update(clauseelement, multiparams, params)
     return clauseelement, multiparams, params
 

--- a/src/crate/client/sqlalchemy/tests/__init__.py
+++ b/src/crate/client/sqlalchemy/tests/__init__.py
@@ -4,6 +4,7 @@ from unittest import TestCase, TestSuite, makeSuite
 from .connection_test import SqlAlchemyConnectionTest
 from .dict_test import SqlAlchemyDictTypeTest
 from .datetime_test import SqlAlchemyDateAndDateTimeTest
+from .compiler_test import SqlAlchemyCompilerTest
 
 
 def test_suite():
@@ -11,4 +12,5 @@ def test_suite():
     tests.addTest(makeSuite(SqlAlchemyConnectionTest))
     tests.addTest(makeSuite(SqlAlchemyDictTypeTest))
     tests.addTest(makeSuite(SqlAlchemyDateAndDateTimeTest))
+    tests.addTest(makeSuite(SqlAlchemyCompilerTest))
     return tests

--- a/src/crate/client/sqlalchemy/tests/compiler_test.py
+++ b/src/crate/client/sqlalchemy/tests/compiler_test.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8; -*-
+#
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+from __future__ import absolute_import
+from unittest import TestCase
+from crate.client.sqlalchemy.compiler import crate_before_execute
+
+import sqlalchemy as sa
+from sqlalchemy.sql import update
+
+from crate.client.sqlalchemy.types import Craty
+
+
+class SqlAlchemyCompilerTest(TestCase):
+
+    def setUp(self):
+        self.crate_engine = sa.create_engine('crate://')
+        self.sqlite_engine = sa.create_engine('sqlite://')
+        metadata = sa.MetaData()
+        self.mytable = sa.Table('mytable', metadata,
+                                sa.Column('name', sa.String),
+                                sa.Column('data', Craty))
+
+        self.update = update(self.mytable, 'where name=:name')
+        self.values = [{'name': 'crate'}]
+
+    def test_sqlite_update_not_rewritten(self):
+        clauseelement, multiparams, params = crate_before_execute(
+            self.sqlite_engine, self.update, self.values, None
+        )
+
+        assert hasattr(clauseelement, '_crate_specific') is False
+
+    def test_crate_update_rewritten(self):
+        clauseelement, multiparams, params = crate_before_execute(
+            self.crate_engine, self.update, self.values, None
+        )
+
+        assert hasattr(clauseelement, '_crate_specific') is True
+


### PR DESCRIPTION
The event listener for crate_before_execute should only modify the query if the event dialect is 'CrateDialect'.
