### PR TITLE
updated crate to 0.46.1 and fixed tests:

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crate
 Unreleased
 ==========
 
+ - run tests against crate 0.46.1
+
 2014/10/27 0.12.3
 =================
 

--- a/docs/client.txt
+++ b/docs/client.txt
@@ -169,8 +169,11 @@ column name as first parameter. Just the name field is supported, all other fiel
      None,
      u'Max Quordlepleen claims that the only thing left ...',
      None,
+     None,
      u'Star System',
      u'Aldebaran',
+     None,
+     None,
      1]
 
     >>> result = cursor.description
@@ -179,8 +182,11 @@ column name as first parameter. Just the name field is supported, all other fiel
      (u'datetime', None, None, None, None, None, None),
      (u'description', None, None, None, None, None, None),
      (u'details', None, None, None, None, None, None),
+     (u'flag', None, None, None, None, None, None),
      (u'kind', None, None, None, None, None, None),
      (u'name', None, None, None, None, None, None),
+     (u'nullable_date', None, None, None, None, None, None),
+     (u'nullable_datetime', None, None, None, None, None, None),
      (u'position', None, None, None, None, None, None))
 
 Closing the Cursor

--- a/src/crate/testing/testdata/mappings/locations.sql
+++ b/src/crate/testing/testdata/mappings/locations.sql
@@ -2,7 +2,10 @@ create table locations (
     name string primary key,
     date timestamp,
     datetime timestamp,
+    nullable_datetime timestamp,
+    nullable_date timestamp,
     kind string,
+    flag boolean,
     position integer,
     description string,
     details array(object)

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,5 +1,5 @@
 [versions]
-crate_server = 0.45.2
+crate_server = 0.46.1
 
 Jinja2 = 2.7.3
 MarkupSafe = 0.23


### PR DESCRIPTION
```
- since crate 0.46.0 it's not possible to query non existing fields
  anymore
```
