### PR TITLE
Client certificate support

### DIFF
--- a/src/crate/client/connection.py
+++ b/src/crate/client/connection.py
@@ -110,6 +110,10 @@ def connect(servers=None, timeout=None, client=None,
     :param ca_cert:
         a path to a CA certificate to use when verifying the SSL server
         certificate.
+    :param cert_file:
+        a path to the client certificate to present to the server.
+    :param key_file:
+        a path to the client key to use when communicating with the server.
     :param error_trace:
         if set to ``True`` return a whole stacktrace of any server error if
         one occurs

--- a/src/crate/client/connection.py
+++ b/src/crate/client/connection.py
@@ -28,7 +28,9 @@ from distutils.version import StrictVersion
 
 class Connection(object):
     def __init__(self, servers=None, timeout=None, client=None,
-                 verify_ssl_cert=False, ca_cert=None, error_trace=False):
+                 verify_ssl_cert=False, ca_cert=None,
+                 cert_file=None, key_file=None,
+                 error_trace=False):
         if client:
             self.client = client
         else:
@@ -36,6 +38,7 @@ class Connection(object):
                                  timeout=timeout,
                                  verify_ssl_cert=verify_ssl_cert,
                                  ca_cert=ca_cert,
+                                 cert_file=cert_file, key_file=key_file,
                                  error_trace=error_trace)
         self.lowest_server_version = self._lowest_server_version()
         self._closed = False
@@ -87,7 +90,9 @@ class Connection(object):
 
 
 def connect(servers=None, timeout=None, client=None,
-            verify_ssl_cert=False, ca_cert=None, error_trace=False):
+            verify_ssl_cert=False, ca_cert=None,
+            cert_file=None, key_file=None,
+            error_trace=False):
     """ Create a :class:Connection object
 
     :param servers:
@@ -114,4 +119,5 @@ def connect(servers=None, timeout=None, client=None,
     """
     return Connection(servers=servers, timeout=timeout, client=client,
                       verify_ssl_cert=verify_ssl_cert, ca_cert=ca_cert,
+                      cert_file=cert_file, key_file=key_file,
                       error_trace=error_trace)

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -70,9 +70,6 @@ def super_len(o):
 class Server(object):
 
     def __init__(self, server, **kwargs):
-        for k,v in kwargs.iteritems():
-            print k
-            print v
         self.pool = urllib3.connection_from_url(server, **kwargs)
 
     def request(self,

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -70,6 +70,9 @@ def super_len(o):
 class Server(object):
 
     def __init__(self, server, **kwargs):
+        for k,v in kwargs.iteritems():
+            print k
+            print v
         self.pool = urllib3.connection_from_url(server, **kwargs)
 
     def request(self,
@@ -117,6 +120,7 @@ class Client(object):
     """Default server to use if no servers are given on instantiation."""
 
     def __init__(self, servers=None, timeout=None, ca_cert=None,
+                 cert_file=None, key_file=None,
                  verify_ssl_cert=False, error_trace=False):
         if not servers:
             servers = [self.default_server]
@@ -127,7 +131,7 @@ class Client(object):
         self._active_servers = servers
         self._inactive_servers = []
         self._http_timeout = timeout
-        pool_kw = {}
+        pool_kw = {'cert_file':cert_file, 'key_file':key_file}
         if ca_cert is None:
             ca_cert = os.environ.get("REQUESTS_CA_BUNDLE", None)
         if ca_cert is not None:
@@ -164,7 +168,7 @@ class Client(object):
                     kwargs_copy = {}
                     #clean up any kwargs which are invalid for HTTPConnectionPool
                     for key in kwargs:
-                        if key not in ['ca_certs', 'cert_reqs']:
+                        if key not in ['ca_certs', 'cert_reqs', 'cert_file', 'key_file']:
                             kwargs_copy[key] = kwargs[key]
                     self.server_pool[server] = Server(server, **kwargs_copy)
                 else:


### PR DESCRIPTION
Allows for optional client certificate / key to be used when connecting to a Crate server via https. This is useful if Crate is running behind a revers proxy that validates client certificates or for modified versions of Crate that support client certificate validation.