### PR TITLE
add python3.5 to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,14 @@ python:
   - 2.7
   - 3.3
   - 3.4
+  - 3.5
 sudo:
     false
 install:
   - pip uninstall -y setuptools
   - python bootstrap.py
   - sed -ir "s/SQLAlchemy = 1.0.0/SQLAlchemy = ${SA_VERSION}/g" versions.cfg
-  - ./bin/buildout
+  - ./bin/buildout -c base.cfg
 env:
   - SA_VERSION=0.8.2
   - SA_VERSION=0.9.8
@@ -20,6 +21,8 @@ matrix:
     - python: 3.3
       env: SA_VERSION=0.8.2
     - python: 3.4
+      env: SA_VERSION=0.8.2
+    - python: 3.5
       env: SA_VERSION=0.8.2
 script:
   - bin/coverage run bin/test

--- a/base.cfg
+++ b/base.cfg
@@ -1,0 +1,32 @@
+[buildout]
+develop = .
+extends = versions.cfg
+versions = versions
+show-picked-versions = true
+parts = test
+        crate
+        scripts
+        coverage
+
+[scripts]
+recipe = zc.recipe.egg:script
+interpreter = py
+eggs = crate
+       crate [test,sqlalchemy]
+       wheel
+       docutils
+
+[coverage]
+recipe = zc.recipe.egg
+eggs = createcoverage
+
+[crate]
+recipe = hexagonit.recipe.download
+url = https://cdn.crate.io/downloads/releases/crate-${versions:crate_server}.tar.gz
+strip-top-level-dir = true
+
+[test]
+relative-paths=true
+recipe = zc.recipe.testrunner
+defaults = ['--auto-color']
+eggs = crate [test,sqlalchemy]

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,40 +1,10 @@
 [buildout]
-develop = .
-extends = versions.cfg
-versions = versions
-show-picked-versions = true
-parts = test
-        crate
-        tox
-        scripts
-        sphinx
-        coverage
-
-[scripts]
-recipe = zc.recipe.egg:script
-interpreter = py
-eggs = crate
-       crate [test,sqlalchemy]
-       wheel
-       docutils
-
-[coverage]
-recipe = zc.recipe.egg
-eggs = createcoverage
+extends = base.cfg
+parts += tox
+         sphinx
 
 [tox]
 recipe = gp.recipe.tox
-
-[crate]
-recipe = hexagonit.recipe.download
-url = https://cdn.crate.io/downloads/releases/crate-${versions:crate_server}.tar.gz
-strip-top-level-dir = true
-
-[test]
-relative-paths=true
-recipe = zc.recipe.testrunner
-defaults = ['--auto-color']
-eggs = crate [test,sqlalchemy]
 
 [sphinx]
 recipe = zc.recipe.egg:script

--- a/versions.cfg
+++ b/versions.cfg
@@ -61,4 +61,4 @@ zope.interface = 4.1.1
 # Required by:
 # zc.recipe.testrunner==2.0.0
 zope.testrunner = 4.4.3
-gp.recipe.tox = 0.3
+gp.recipe.tox = 0.4


### PR DESCRIPTION
somehow the tox recipe doesn't work on travis under
python3.5. I tried to fix that with
https://github.com/gawel/gp.recipe.tox/pull/1 and while that
does fix things for me locally it broke the travis build for
3.3, 3.4 and 3.5 (3.3 is odd because the behaviour for 3.3
is actually unchanged. 3.4 and 3.5 broke because pip is
missing. Which is odd too because `venv.create(..,
with_pip=True)` should ensure that it is there. Which is
actually the case locally, just not on travis).

To work around all that hassle I simply split up the
buildout configurations to not install the tox and sphinx
recipes in the travis run as they're not needed anyway.
