### PR TITLE
Make sqlalchemy Object column policies configurable

### DIFF
--- a/src/crate/client/sqlalchemy/tests/create_table_test.py
+++ b/src/crate/client/sqlalchemy/tests/create_table_test.py
@@ -1,7 +1,7 @@
 import sqlalchemy as sa
 from sqlalchemy.ext.declarative import declarative_base
 
-from crate.client.sqlalchemy.types import Object
+from crate.client.sqlalchemy.types import IgnoredObject, Object, StrictObject
 from crate.client.cursor import Cursor
 
 from mock import patch, MagicMock
@@ -53,6 +53,32 @@ class CreateTableTest(TestCase):
         fake_cursor.execute.assert_called_with(
             ('\nCREATE TABLE dummy (\n\tpk STRING, \n\tobj_col OBJECT, '
              '\n\tPRIMARY KEY (pk)\n)\n\n'),
+            ()
+        )
+
+    def test_with_strict_obj_column(self):
+        class DummyTable(self.Base):
+            __tablename__ = 'dummy'
+            pk = sa.Column(sa.String, primary_key=True)
+            obj_col = sa.Column(StrictObject)
+        self.Base.metadata.create_all()
+        fake_cursor.execute.assert_called_with(
+            ('\nCREATE TABLE dummy (\n\tpk STRING, \n\t'
+             'obj_col OBJECT(strict), \n\t'
+             'PRIMARY KEY (pk)\n)\n\n'),
+            ()
+        )
+
+    def test_with_ignored_obj_column(self):
+        class DummyTable(self.Base):
+            __tablename__ = 'dummy'
+            pk = sa.Column(sa.String, primary_key=True)
+            obj_col = sa.Column(IgnoredObject)
+        self.Base.metadata.create_all()
+        fake_cursor.execute.assert_called_with(
+            ('\nCREATE TABLE dummy (\n\tpk STRING, \n\t'
+             'obj_col OBJECT(ignored), \n\t'
+             'PRIMARY KEY (pk)\n)\n\n'),
             ()
         )
 

--- a/src/crate/client/sqlalchemy/types.py
+++ b/src/crate/client/sqlalchemy/types.py
@@ -117,14 +117,21 @@ class _Craty(sqltypes.UserDefinedType):
                 return default_comparator._binary_operate(self.expr, operators.getitem, key)
             return self._binary_operate(self.expr, operators.getitem, key)
 
+    def __init__(self, column_policy=None):
+        self.column_policy = column_policy
+
     def get_col_spec(self):
-        return 'OBJECT'
+        if self.column_policy is None:
+            return 'OBJECT'
+        return 'OBJECT(%s)' % self.column_policy
 
     type = MutableDict
     comparator_factory = Comparator
 
-
-Object = Craty = MutableDict.as_mutable(_Craty)
+DynamicObject = MutableDict.as_mutable(_Craty)
+StrictObject = MutableDict.as_mutable(_Craty('strict'))
+IgnoredObject = MutableDict.as_mutable(_Craty('ignored'))
+Object = Craty = DynamicObject
 
 
 class Any(expression.ColumnElement):


### PR DESCRIPTION
Right now it is not easily possible to use a different column policy when using the Object type. This commit makes it easier and is backwards compatible.

Due to as_mutable() always returning an instance, it is not possible (to my knowledge) to extend the Object type "the sqlalchemy way" eg.

```python
# default Object column
object1 = Column(Object)

# throws TypeError because Object is already an instance
object2 = Column(Object('dynamic'))   
```

My solution is a little verbose, extends the api, the naming is also not optimal. if it is too much, you could keep only the changes from the _Craty class and they would still make configuring column policies way easier eg.

```python
# complete solution
object1 = Column(StrictObject)

# minimal change solution
object2 = Column(MutableDict.as_mutable(_Craty('strict')))   
```