### PR TITLE
Fix sqlalchemy create table compiler

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crate
 Unreleased
 ==========
 
+- fix: use proper CLUSTERED clause syntax in SQLAlchemy's create table statement
+
 2015/08/12 0.13.4
 =================
 

--- a/src/crate/client/sqlalchemy/tests/create_table_test.py
+++ b/src/crate/client/sqlalchemy/tests/create_table_test.py
@@ -104,3 +104,20 @@ class CreateTableTest(TestCase):
              'pk STRING, \n\t'
              'PRIMARY KEY (pk)\n'
              ') CLUSTERED INTO 3 SHARDS WITH (NUMBER_OF_REPLICAS = 2)\n\n'), ())
+
+    def test_with_clustered_by_and_number_of_shards(self):
+        class DummyTable(self.Base):
+            __tablename__ = 't'
+            __table_args__ = {
+                'crate_clustered_by': 'p',
+                'crate_number_of_shards': 3
+            }
+            pk = sa.Column(sa.String, primary_key=True)
+            p = sa.Column(sa.String, primary_key=True)
+        self.Base.metadata.create_all()
+        fake_cursor.execute.assert_called_with(
+            ('\nCREATE TABLE t (\n\t'
+             'pk STRING, \n\t'
+             'p STRING, \n\t'
+             'PRIMARY KEY (pk, p)\n'
+             ') CLUSTERED BY (p) INTO 3 SHARDS\n\n'), ())


### PR DESCRIPTION
The create table compiler produces incorrect sql when  'crate_clustered_by' and  'crate_number_of_shards'  ``__table_args__`` are used simultaneously.

In this example I'm using a minimal SQL generated by sqlalchemy:
```sql
cr> CREATE TABLE test (
        p STRING
) CLUSTERED INTO 3 SHARDS CLUSTERED BY (p);
CREATE OK (0.077 sec)

cr> select table_name, number_of_shards from information_schema.tables where table_name='test11';
+------------+------------------+
| table_name | number_of_shards |
+------------+------------------+
| test       |                5 |
+------------+------------------+
SELECT 1 row in set (0.002 sec)
```
The number of shards is 5, but it should be 3 ...

The syntax doesn't seem to be valid (according to "[ CLUSTERED [ BY (routing_column) ] INTO num_shards SHARDS ]"), but the crate client generates this sql and the crate database doesn't throw a syntax error (both crash and admin console), instead it seems that only the last "CLUSTERED" statement is used and the first is ignored.
