### PR TITLE
remove lovely.testlayers dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -71,8 +71,7 @@ setup(
         ]
     },
     extras_require=dict(
-        test=['lovely.testlayers',
-              'mock>=1.0.1',
+        test=['mock>=1.0.1',
               'zope.testing',
               'zc.customdoctests>=1.0.1'],
         sqlalchemy=['sqlalchemy>=0.8.2']

--- a/src/crate/client/http.txt
+++ b/src/crate/client/http.txt
@@ -161,7 +161,7 @@ Error Handling
 It's possible to define a HTTP timeout in seconds on client instantiation, so a timeout exception
 is raised when timeout is reached::
 
-    >>> http_client = HttpClient(crate_host, timeout=0.00000001)
+    >>> http_client = HttpClient(crate_host, timeout=0)
     >>> http_client.sql('select name from locations')
     Traceback (most recent call last):
     ...

--- a/src/crate/client/tests.py
+++ b/src/crate/client/tests.py
@@ -79,7 +79,6 @@ crate_port = 44209
 crate_transport_port = 44309
 crate_layer = CrateLayer('crate',
                          crate_home=crate_path(),
-                         crate_exec=crate_path('bin', 'crate'),
                          port=crate_port,
                          transport_port=crate_transport_port)
 

--- a/src/crate/testing/layer.py
+++ b/src/crate/testing/layer.py
@@ -7,19 +7,21 @@ import logging
 import urllib3
 import tempfile
 import shutil
+import subprocess
 from urllib3.exceptions import MaxRetryError
-from lovely.testlayers import server, layer
 
 logger = logging.getLogger(__name__)
 
-class CrateLayer(server.ServerLayer):
+class CrateLayer(object):
     """
     this layer starts a crate server.
     """
 
+    __bases__ = ()
+
     tmpdir = tempfile.gettempdir()
     wait_interval = 0.2
-    conn_pool = urllib3.PoolManager()
+    conn_pool = urllib3.PoolManager(num_pools=1)
 
     def __init__(self,
                  name,
@@ -48,10 +50,12 @@ class CrateLayer(server.ServerLayer):
         :param settings: further settings that do not deserve a keyword argument
                          will be prefixed with ``es.``.
         """
+        self.__name__ = name
         self.keepRunning = keepRunning
         crate_home = os.path.abspath(crate_home)
         if crate_exec is None:
-            crate_exec = os.path.join(crate_home, 'bin', 'crate')
+            start_script = 'crate.bat' if sys.platform == 'win32' else 'crate'
+            crate_exec = os.path.join(crate_home, 'bin', start_script)
         if crate_config is None:
             crate_config = os.path.join(crate_home, 'config', 'crate.yml')
         if cluster_name is None:
@@ -59,14 +63,11 @@ class CrateLayer(server.ServerLayer):
         settings = self.create_settings(crate_config, cluster_name, name, host, port, transport_port, multicast, settings)
         start_cmd = (crate_exec, ) + tuple(["-Des.%s=%s" % opt for opt in settings.items()])
 
-        server = '%s:%s' % (settings["network.host"], settings["http.port"])
-        self.crate_servers = ['http://%s' % server]
+        self.http_url = 'http://{host}:{port}'.format(
+            host=settings['network.host'], port=settings['http.port'])
 
-        self.wd = wd = os.path.join(CrateLayer.tmpdir, 'crate_layer', name)
-        if os.path.exists(wd):
-            shutil.rmtree(wd)
-        start_cmd = start_cmd + ('-Des.path.data="%s"' % wd,)
-        super(CrateLayer, self).__init__(name, servers=[server], start_cmd=start_cmd)
+        self._wd = wd = os.path.join(CrateLayer.tmpdir, 'crate_layer', name)
+        self.start_cmd = start_cmd + ('-Des.path.data=%s' % wd,)
 
     def create_settings(self,
                         crate_config,
@@ -99,16 +100,36 @@ class CrateLayer(server.ServerLayer):
         return settings
 
     def wdPath(self):
-        return self.wd
+        return self._wd
+
+    @property
+    def crate_servers(self):
+        return [self.http_url]
+
+    def setUp(self):
+        self.start()
 
     def start(self):
-        super(CrateLayer, self).start()
-        self.wait_for_start()
-        self.wait_for_master()
+        if os.path.exists(self._wd):
+            shutil.rmtree(self._wd)
+
+        self.process = subprocess.Popen(self.start_cmd)
+        returncode = self.process.poll()
+        if returncode is not None:
+            raise SystemError('Failed to start server rc={0} cmd={1}'.format(
+                returncode, self.start_cmd))
+        self._wait_for_start()
+        self._wait_for_master()
+
+    def stop(self):
+        self.process.kill()
+
+    def tearDown(self):
+        self.stop()
 
     def _wait_for(self, validator):
         time_slept = 0
-        max_wait_for_connection = 5  # secs
+        max_wait_for_connection = 20  # secs
 
         while True:
             try:
@@ -127,23 +148,23 @@ class CrateLayer(server.ServerLayer):
             time_slept += self.wait_interval
 
 
-    def wait_for_start(self):
+    def _wait_for_start(self):
         """Wait for instance to be started"""
 
         # since crate 0.10.0 http may be ready before the cluster is fully available
         # block here so that early requests after the layer starts don't result in 503
         def validator():
-            url = '{server}/'.format(server=self.crate_servers[0])
+            url = '{server}/'.format(server=self.http_url)
             resp = self.conn_pool.request('HEAD', url)
             return resp.status == 200
 
         self._wait_for(validator)
 
-    def wait_for_master(self):
+    def _wait_for_master(self):
         """Wait for master node"""
 
         def validator():
-            url = '{server}/_sql'.format(server=self.crate_servers[0])
+            url = '{server}/_sql'.format(server=self.http_url)
             resp = self.conn_pool.urlopen('POST', url,
                 headers={'Content-Type': 'application/json'},
                 body='{"stmt": "select master_node from sys.cluster"}')

--- a/src/crate/testing/layer.txt
+++ b/src/crate/testing/layer.txt
@@ -16,7 +16,6 @@ a given crate node name and, optionally, a given cluster name::
 
     >>> layer =  CrateLayer('crate',
     ...                     crate_home=crate_path(),
-    ...                     crate_exec=crate_path('bin', 'crate'),
     ...                     host='127.0.0.1',
     ...                     port=port,
     ...                     transport_port=transport_port,
@@ -33,7 +32,7 @@ The working directory is defined on layer instantiation.
 It is sometimes required to know it before starting the layer::
 
     >>> layer.wdPath()
-    '.../crate.testing.layer.CrateLayer.crate/work'
+    '...crate_layer/crate'
 
 Lets start the layer::
 
@@ -69,12 +68,6 @@ to ``localhost``::
 
     >>> layer_defaults.crate_servers
     ['http://localhost:4200']
-
-The working directory will be places inside a temporary directory made up using
-the layer name::
-
-    >>> layer_defaults.wdPath()
-    '.../crate.testing.layer.CrateLayer.crate_defaults/work'
 
 The command to call is ``bin/crate`` inside the ``crate_home`` path.
 The default config file is ``config/crate.yml`` inside ``crate_home``.

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,6 @@ deps =
     zope.testrunner
     zope.testing
     zc.customdoctests
-    lovely.testlayers
     sa_0_8: sqlalchemy==0.8.2
     sa_0_9: sqlalchemy==0.9.8
     sa_1_0: sqlalchemy>=1.0.0

--- a/versions.cfg
+++ b/versions.cfg
@@ -11,7 +11,6 @@ crate-docs-theme = 0.3.6
 createcoverage = 1.2
 docutils = 0.12
 hexagonit.recipe.download = 1.7
-lovely.testlayers = 0.6.0
 mock = 1.0.1
 py = 1.4.26
 tox = 1.8.1
@@ -27,7 +26,6 @@ zc.buildout = 2.3.1
 # Required by:
 # crate==0.12.3
 # createcoverage==1.2
-# lovely.testlayers==0.6.0
 # zc.customdoctests==1.0.1
 # zope.exceptions==4.0.7
 # zope.interface==4.1.1


### PR DESCRIPTION
The functionality that was used of the ServerLayer is
basically just subprocess Popen and kill.

Everything else was either un-used (e.g. stdout/stderr
handling) or unneeded (waiting for the process to become
responsive on its port - the crate layer has that
functionality already with the addition of waiting for HTTP
200 status codes)