### PR TITLE
remove wheel and docutils dependency in base.cfg

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -13,8 +13,6 @@ recipe = zc.recipe.egg:script
 interpreter = py
 eggs = crate
        crate [test,sqlalchemy]
-       wheel
-       docutils
 
 [coverage]
 recipe = zc.recipe.egg

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -2,6 +2,12 @@
 extends = base.cfg
 parts += tox
          sphinx
+         scripts
+
+[scripts]
+recipe = zc.recipe.egg:script
+eggs = wheel
+       docutils
 
 [tox]
 recipe = gp.recipe.tox

--- a/versions.cfg
+++ b/versions.cfg
@@ -33,7 +33,7 @@ zc.buildout = 2.3.1
 # zope.interface==4.1.1
 # zope.testing==4.1.3
 # zope.testrunner==4.4.3
-setuptools = 12.0.4
+setuptools = 18.5
 
 # Required by:
 # crate==0.12.3


### PR DESCRIPTION
these dependencies are only useful if one wants to do a release and are
generally not required to run tests