### PR TITLE
add support for datetime serialization

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crate
 Unreleased
 ==========
 
+ - Added support for serialization of datetime objects
+
 2015/10/21 0.13.6
 =================
 


### PR DESCRIPTION
Other db-api implementations (e.g. sqlite3) support datetime instances
in `execute` calls.

E.g. it is possible to do something like:

    c.execute('insert into t (dt) values (?)', (datetime.utcnow(),))

This commit adds the same functionality.