### PR TITLE
increased retry_interval in  ThreadSafeHttpClientTest to ensure that

### DIFF
--- a/src/crate/client/test_http.py
+++ b/src/crate/client/test_http.py
@@ -239,7 +239,7 @@ class ThreadSafeHttpClientTest(TestCase):
 
     def setUp(self):
         self.client = Client(self.servers)
-        self.client.retry_interval = 0.0001  # faster retry
+        self.client.retry_interval = 0.1  # faster retry
 
     def _run(self):
         self.event.wait()  # wait for the others


### PR DESCRIPTION
servers which where set to inactive state
will not be put back to active state immediately, which would cause an endless loop