### PR TITLE
disable http retries on read errors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crate
 Unreleased
 ==========
 
+ - Fix: Never retry on http read errors (so never send SQL statements twice)
+
 2016/03/10 0.14.1
 =================
 

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -29,6 +29,7 @@ import sys
 import six
 import urllib3
 import urllib3.exceptions
+from urllib3.util.retry import Retry
 from time import time
 from datetime import datetime, date
 import calendar
@@ -108,6 +109,7 @@ class Server(object):
         headers['Accept'] = 'application/json'
         kwargs['assert_same_host'] = False
         kwargs['redirect'] = False
+        kwargs['retries'] = Retry(read=0)
         return self.pool.urlopen(
             method,
             path,

--- a/src/crate/client/tests.py
+++ b/src/crate/client/tests.py
@@ -49,7 +49,7 @@ from .test_http import (
     ThreadSafeHttpClientTest,
     KeepAliveClientTest,
     ParamsTest,
-)
+    RetryOnTimeoutServerTest)
 from .sqlalchemy.tests import test_suite as sqlalchemy_test_suite
 from .sqlalchemy.types import ObjectArray
 from .compat import cprint
@@ -283,6 +283,7 @@ def test_suite():
     suite.addTest(unittest.makeSuite(ThreadSafeHttpClientTest))
     suite.addTest(unittest.makeSuite(ParamsTest))
     suite.addTest(unittest.makeSuite(ConnectionTest))
+    suite.addTest(unittest.makeSuite(RetryOnTimeoutServerTest))
     suite.addTest(sqlalchemy_test_suite())
     suite.addTest(doctest.DocTestSuite('crate.client.connection'))
     suite.addTest(doctest.DocTestSuite('crate.client.http'))


### PR DESCRIPTION
Read retries by default are set to 3, which will send an SQL statement up to 4 times if e.g. an read timeout occurs. This commit disables read retries at all.