### PR TITLE
Move cert removal for non-https into a separate method

### DIFF
--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -207,7 +207,7 @@ def _pool_kw_args(ca_cert, verify_ssl_cert):
 def _remove_certs_for_non_https(server, kwargs):
     if server.lower().startswith('https'):
         return kwargs
-    used_ssl_args = SSL_ONLY_ARGS & kwargs.keys()
+    used_ssl_args = SSL_ONLY_ARGS & set(kwargs.keys())
     if used_ssl_args:
         kwargs = kwargs.copy()
         for arg in used_ssl_args:

--- a/src/crate/client/test_http.py
+++ b/src/crate/client/test_http.py
@@ -34,7 +34,7 @@ from multiprocessing import Process
 import datetime as dt
 import urllib3.exceptions
 
-from .http import Client
+from .http import Client, _remove_certs_for_non_https
 from .exceptions import ConnectionError, ProgrammingError
 from .compat import xrange, BaseHTTPServer, to_bytes
 
@@ -370,6 +370,14 @@ class RequestsCaBundleTest(TestCase):
             Client('http://127.0.0.1:4200')
         except ProgrammingError:
             self.fail("HTTP not working with REQUESTS_CA_BUNDLE")
+
+    def test_remove_certs_for_non_https(self):
+        d = _remove_certs_for_non_https('https', {"ca_certs": 1})
+        self.assertTrue('ca_certs' in d)
+
+        d = _remove_certs_for_non_https('http', {"ca_certs": 1, 'foobar': 2})
+        self.assertTrue('ca_certs' not in d)
+        self.assertTrue('foobar' in d)
 
 
 class RetryRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):

--- a/src/crate/client/tests.py
+++ b/src/crate/client/tests.py
@@ -49,7 +49,9 @@ from .test_http import (
     ThreadSafeHttpClientTest,
     KeepAliveClientTest,
     ParamsTest,
-    RetryOnTimeoutServerTest)
+    RetryOnTimeoutServerTest,
+    RequestsCaBundleTest
+)
 from .sqlalchemy.tests import test_suite as sqlalchemy_test_suite
 from .sqlalchemy.types import ObjectArray
 from .compat import cprint
@@ -284,6 +286,7 @@ def test_suite():
     suite.addTest(unittest.makeSuite(ParamsTest))
     suite.addTest(unittest.makeSuite(ConnectionTest))
     suite.addTest(unittest.makeSuite(RetryOnTimeoutServerTest))
+    suite.addTest(unittest.makeSuite(RequestsCaBundleTest))
     suite.addTest(sqlalchemy_test_suite())
     suite.addTest(doctest.DocTestSuite('crate.client.connection'))
     suite.addTest(doctest.DocTestSuite('crate.client.http'))


### PR DESCRIPTION
Also adds RequestsCaBundleTest to the testsuite. Before it wasn't
executed