### PR TITLE
Drop support for Python 2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 2.6
   - 2.7
   - 3.3
   - 3.4

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crate
 Unreleased
 ==========
 
+ - Dropped support for Python 2.6
+
 2016/03/18 0.14.2
 =================
 

--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,9 @@ To update use::
     $ pip install -U crate
 
 
+Python 2.6 is only supported up to and including version ``0.14``.
+
+
 Are you a Developer?
 ====================
 

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{py,26,27}-sa_{0_8,0_9,1_0}, py{33,34}-sa_{0_9,1_0}
+envlist = py{py,27}-sa_{0_8,0_9,1_0}, py{33,34}-sa_{0_9,1_0}
 
 [testenv]
 usedevelop = True


### PR DESCRIPTION
Python 2.6 reached end of line in 2013 and since then doesn't receive
any security updates.