### PR TITLE
do not rely on startup log if static http port for test layer is defined

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crate
 Unreleased
 ==========
 
+ - Testing: Do not rely on startup log if static http port is defined in test
+   layer.
+
 2016/06/23 0.16.1
 =================
 

--- a/src/crate/testing/layer.txt
+++ b/src/crate/testing/layer.txt
@@ -54,6 +54,28 @@ The layer can be shutdown using its ``stop()`` method::
 
     >>> layer.stop()
 
+Dynamic HTTP Port
+-----------------
+
+It is also possible to define a port range instead of a static HTTP port for
+the layer::
+
+    >>> port = '44200-44299'
+    >>> layer = CrateLayer('crate',
+    ...                    crate_home=crate_path(),
+    ...                    port=port,
+    ... )
+    >>> layer.start()
+    >>> layer.crate_servers
+    ['http://127.0.0.1:442...']
+    >>> layer.stop()
+
+Crate will start with the first available port in the given range and the test
+layer obtains the chosen port from the startup logs of the Crate process.
+Note, that this feature requires a logging configuration with at least loglevel
+``INFO`` on ``http``.
+
+
 Default Values
 --------------
 
@@ -96,9 +118,9 @@ the command line flag: ``-Des.threadpool.bulk.queue_size=100``::
     ...     crate_path(),
     ...     port=44401,
     ...     settings = {
-    ...                    "cluster.graceful_stop.min_availability": "none",
-    ...                    "http.port": 44402
-    ...                }
+    ...         "cluster.graceful_stop.min_availability": "none",
+    ...         "http.port": 44402
+    ...     }
     ... )
 
     >>> custom_layer.start()

--- a/src/crate/testing/test_layer.py
+++ b/src/crate/testing/test_layer.py
@@ -1,0 +1,48 @@
+# -*- coding: utf-8; -*-
+#
+# Licensed to CRATE Technology GmbH ("Crate") under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  Crate licenses
+# this file to you under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.  You may
+# obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# However, if you have executed another commercial license agreement
+# with Crate these terms will supersede the license and you may use the
+# software solely pursuant to the terms of the relevant commercial agreement.
+
+from unittest import TestCase
+from .layer import prepend_http, http_url_from_host_port
+
+
+class LayerUtilsTest(TestCase):
+
+    def test_prepend_http(self):
+        host = prepend_http('localhost')
+        self.assertEqual('http://localhost', host)
+        host = prepend_http('http://localhost')
+        self.assertEqual('http://localhost', host)
+        host = prepend_http('https://localhost')
+        self.assertEqual('https://localhost', host)
+        host = prepend_http('http')
+        self.assertEqual('http://http', host)
+
+    def test_http_url(self):
+        url = http_url_from_host_port(None, None)
+        self.assertEqual(None, url)
+        url = http_url_from_host_port('localhost', None)
+        self.assertEqual(None, url)
+        url = http_url_from_host_port(None, 4200)
+        self.assertEqual(None, url)
+        url = http_url_from_host_port('localhost', 4200)
+        self.assertEqual('http://localhost:4200', url)
+        url = http_url_from_host_port('https://crate', 4200)
+        self.assertEqual('https://crate:4200', url)

--- a/src/crate/testing/tests.py
+++ b/src/crate/testing/tests.py
@@ -27,6 +27,7 @@ import unittest
 import doctest
 import tempfile
 from zope.testing.renormalizing import RENormalizing
+from .test_layer import LayerUtilsTest
 
 def docs_path(*parts):
     return os.path.join(os.path.dirname(os.path.dirname(__file__)), *parts)
@@ -55,4 +56,5 @@ def test_suite():
                              checker=checker,
                              encoding='utf-8')
     suite.addTest(s)
+    suite.addTest(unittest.makeSuite(LayerUtilsTest))
     return suite


### PR DESCRIPTION
fixes #173 