### PR TITLE
expose verbosity on test layer

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crate
 Unreleased
 ==========
 
+ - Testing: Made Crate test layer logging less verbose (hide Crate startup logs)
+   and added ``verbose keyword`` argument to layer to control its verbosity.
+
  - Testing: Do not rely on startup log if static http port is defined in test
    layer.
 

--- a/src/crate/testing/layer.txt
+++ b/src/crate/testing/layer.txt
@@ -130,6 +130,24 @@ the command line flag: ``-Des.threadpool.bulk.queue_size=100``::
     True
     >>> custom_layer.stop()
 
+
+Verbosity
+---------
+
+The test layer hides the standard output of Crate per default. To increase the
+verbosity level the additional keyword argument ``verbose`` needs to be set
+to ``True``.
+
+    >>> layer =  CrateLayer('crate',
+    ...                     crate_home=crate_path(),
+    ...                     verbose=True
+    ... )
+
+    >>> layer.start()
+    >>> layer.verbose
+    True
+    >>> layer.stop()
+
 Starting a Cluster
 ------------------
 


### PR DESCRIPTION
Set `verbosity=True` will enable the standard output of the Crate
subprocess.