### PR TITLE
Remove certificate keywords when adding non-https server

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Changes for crate
 
 Unreleased
 ==========
+ - Fix: Avoid invalid keyword argument error when fetching blobs from cluster
+   by removing certificate keywords before creating non-https server in pool.
 
  - Testing: Made Crate test layer logging less verbose (hide Crate startup logs)
    and added ``verbose keyword`` argument to layer to control its verbosity.
@@ -11,7 +13,7 @@ Unreleased
 2016/07/22 0.16.2
 =================
 
- - Increased ``urllib3`` version requirement to >=1.9 to prevent from 
+ - Increased ``urllib3`` version requirement to >=1.9 to prevent from
    compatibility issues.
 
  - Testing: Do not rely on startup log if static http port is defined in test

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -365,7 +365,8 @@ class Client(object):
     def _add_server(self, server):
         with self._lock:
             if server not in self.server_pool:
-                self.server_pool[server] = Server(server, **self._pool_kw)
+                kwargs = _remove_certs_for_non_https(server, self._pool_kw)
+                self.server_pool[server] = Server(server, **kwargs)
 
     def _request(self, method, path, server=None, **kwargs):
         """Execute a request to the cluster

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -283,10 +283,13 @@ class Client(object):
         for server in self.server_pool.values():
             server.close()
 
+    def _create_server(self, server, **kwargs):
+        kwargs = _remove_certs_for_non_https(server, kwargs)
+        self.server_pool[server] = Server(server, **kwargs)
+
     def _update_server_pool(self, servers, **kwargs):
         for server in servers:
-            kwargs = _remove_certs_for_non_https(server, kwargs)
-            self.server_pool[server] = Server(server, **kwargs)
+            self._create_server(server, **kwargs)
 
     def sql(self, stmt, parameters=None, bulk_parameters=None):
         """
@@ -365,8 +368,7 @@ class Client(object):
     def _add_server(self, server):
         with self._lock:
             if server not in self.server_pool:
-                kwargs = _remove_certs_for_non_https(server, self._pool_kw)
-                self.server_pool[server] = Server(server, **kwargs)
+                self._create_server(server, **self._pool_kw)
 
     def _request(self, method, path, server=None, **kwargs):
         """Execute a request to the cluster


### PR DESCRIPTION
This pull request addresses the following exception which can occur while fetching blob data from a cluster with multiple non-https servers:

```
Traceback (most recent call last):
  File "BlobAccess.py", line 29, in <module>
    iter = blob_container.get(blob_dict[k])
  File "C:\Anaconda2\envs\sandbox\lib\site-packages\crate\client\blob.py", line 80, in get
    return self.conn.client.blob_get(self.container_name, digest)
  File "C:\Anaconda2\envs\sandbox\lib\site-packages\crate\client\http.py", line 347, in blob_get
    response = self._request('GET', _blob_path(table, digest), stream=True)
  File "C:\Anaconda2\envs\sandbox\lib\site-packages\crate\client\http.py", line 406, in _request
    raise ProgrammingError(_ex_to_message(e))
crate.client.exceptions.ProgrammingError: __init__() got an unexpected keyword argument 'cert_file'
```