### PR TITLE
Fix: get_table_names

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crate
 Unreleased
 ==========
 
+ - Fix sqlalchemy: ``sa.inspect(engine).get_table_names`` failed due
+   to an attribute error
+
 2016/11/21 0.16.5
 =================
 

--- a/src/crate/client/sqlalchemy/dialect.py
+++ b/src/crate/client/sqlalchemy/dialect.py
@@ -36,9 +36,7 @@ from crate.client.exceptions import TimezoneUnawareException
 
 from .sa_version import SA_1_0, SA_VERSION
 
-from distutils.version import StrictVersion
-
-SCHEMA_MIN_VERSION = StrictVersion("0.57.0")
+SCHEMA_MIN_VERSION = (0, 57, 0)
 
 log = logging.getLogger(__name__)
 
@@ -187,9 +185,8 @@ class CrateDialect(default.DefaultDialect):
 
     @reflection.cache
     def get_table_names(self, connection, schema=None, **kw):
-        version = connection.connection.lowest_server_version
         schema_name = \
-            "table_schema" if version >= SCHEMA_MIN_VERSION else "schema_name"
+            "table_schema" if self.server_version_info >= SCHEMA_MIN_VERSION else "schema_name"
 
         cursor = connection.execute(
             "select table_name from information_schema.tables "

--- a/src/crate/client/sqlalchemy/dialect.txt
+++ b/src/crate/client/sqlalchemy/dialect.txt
@@ -8,8 +8,6 @@ The initialize method sets the default schema name and version info::
     >>> dialect = CrateDialect()
     >>> dialect.initialize(connection)
 
-    >>> dialect.default_schema_name
-    'doc'
 
     >>> dialect.server_version_info >= (0, 54, 6)
     True
@@ -19,25 +17,11 @@ Check if table exists::
     >>> dialect.has_table(connection, 'locations')
     True
 
-List all tables::
-
-    >>> dialect.get_table_names(connection)
-    ['characters', 'locations']
-
-    >>> dialect.get_table_names(connection, schema='sys')[:4]
-    ['checks', 'cluster', 'jobs', 'jobs_log']
-
 Check if schema exists::
 
     >>> dialect.has_schema(connection, 'doc')
     True
 
-List all schemas::
-
-    >>> dialect.get_schema_names(connection)
-    [u'blob', u'doc', u'information_schema', u'sys']
-
 .. Hidden: close connection
 
     >>> connection.close()
-

--- a/src/crate/client/sqlalchemy/reflection.txt
+++ b/src/crate/client/sqlalchemy/reflection.txt
@@ -1,0 +1,23 @@
+=================================
+SQLAlchemy Dialect and Reflection
+=================================
+
+    >>> inspector = sa.inspect(engine)
+
+List all schemas::
+
+    >>> inspector.get_schema_names()
+    ['blob', 'doc', 'information_schema', 'sys']
+
+List all tables::
+
+    >>> inspector.get_table_names()
+    ['characters', 'locations']
+
+    >>> inspector.get_table_names(schema='sys')[:4]
+    ['checks', 'cluster', 'jobs', 'jobs_log']
+
+Get default schema name::
+
+    >>> inspector.default_schema_name
+    'doc'

--- a/src/crate/client/tests.py
+++ b/src/crate/client/tests.py
@@ -313,6 +313,7 @@ def test_suite():
     s = doctest.DocFileSuite(
         'sqlalchemy/itests.txt',
         'sqlalchemy/dialect.txt',
+        'sqlalchemy/reflection.txt',
         checker=checker,
         setUp=setUpCrateLayerAndSqlAlchemy,
         tearDown=tearDownWithCrateLayer,


### PR DESCRIPTION
* Fix: removed usage of connection.lowest_server_version in get_table_names, cause the passed connection is an SQLAlchemy.BaseConnection which doesn’t  have this attribute
* created an integration test which uses sa.inspect and moved test cases from the dialect integration test 