### PR TITLE
sqlalchemy: fixed version check agains alpha and beta

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for crate
 Unreleased
 ==========
 
+ - Fix sqlalchemy: crate dialect didn't work properly with alpha and beta
+   versions of sqlalchemy due to a wrong version check
+   (e.g.: sandman2 depends on 1.1.0b3)
+
  - sqlalchemy: added support for native Arrays
 
  - Fix sqlalchemy: ``sa.inspect(engine).get_table_names`` failed due

--- a/src/crate/client/sqlalchemy/sa_version.py
+++ b/src/crate/client/sqlalchemy/sa_version.py
@@ -24,5 +24,5 @@ from distutils.version import StrictVersion as V
 
 SA_VERSION = V(sa.__version__)
 
-SA_1_0 = V('1.0')
-SA_1_1 = V('1.1')
+SA_1_0 = V('1.0a0')
+SA_1_1 = V('1.1a0')


### PR DESCRIPTION
as StrictVersion(1.1) > StrictVersion(1.1a0) the version checks against alpha and beta versions are wrong