### PR TITLE
Fix cmd line settings to be passed with -C and not -Des.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,9 @@ Changes for crate
 Unreleased
 ==========
 
- - Testing: Dropped  ``multicast`` support for Crate test layer
+ - BREAKING: Dropped Crate version < 1.0.0 support for Crate test layer
+
+ - Testing: Dropped ``multicast`` support for Crate test layer
 
  - Added support for ``Insert`` from select to the SQLAlchemy dialect
 

--- a/src/crate/testing/layer.py
+++ b/src/crate/testing/layer.py
@@ -201,11 +201,11 @@ class CrateLayer(object):
                                         port or '4200-4299',
                                         transport_port or '4300-4399',
                                         settings)
-        start_cmd = (crate_exec, ) + tuple(["-Des.%s=%s" % opt
-                                           for opt in settings.items()])
+        start_cmd = (crate_exec, ) + tuple(["-C%s=%s" % opt
+                                            for opt in settings.items()])
 
         self._wd = wd = os.path.join(CrateLayer.tmpdir, 'crate_layer', name)
-        self.start_cmd = start_cmd + ('-Des.path.data=%s' % wd,)
+        self.start_cmd = start_cmd + ('-Cpath.data=%s' % wd,)
 
     def create_settings(self,
                         crate_config,

--- a/src/crate/testing/layer.txt
+++ b/src/crate/testing/layer.txt
@@ -107,9 +107,9 @@ The ``Crate`` layer can be started with additional settings as well.
 Add a dictionary for keyword argument ``settings`` which contains your settings.
 Those additional setting will override settings given as keyword argument.
 
-The settings will be prefixed with ``es.`` and handed over to the ``Crate``
-process with the ``-D`` flag. So the setting ``threadpool.bulk.queue_size: 100`` becomes
-the command line flag: ``-Des.threadpool.bulk.queue_size=100``::
+The settings will handed over to the ``Crate`` process with the ``-C`` flag.
+So the setting ``threadpool.bulk.queue_size: 100`` becomes
+the command line flag: ``-Cthreadpool.bulk.queue_size=100``::
 
     >>> custom_layer = CrateLayer(
     ...     'custom',
@@ -124,7 +124,7 @@ the command line flag: ``-Des.threadpool.bulk.queue_size=100``::
     >>> custom_layer.start()
     >>> custom_layer.crate_servers
     ['http://127.0.0.1:44402']
-    >>> '-Des.cluster.graceful_stop.min_availability=none' in custom_layer.start_cmd
+    >>> '-Ccluster.graceful_stop.min_availability=none' in custom_layer.start_cmd
     True
     >>> custom_layer.stop()
 

--- a/src/crate/testing/layer.txt
+++ b/src/crate/testing/layer.txt
@@ -205,15 +205,15 @@ From Uri
 The CrateLayer can also be created by providing a URI that points to a Crate
 tarball::
 
-    >>> uri = 'https://cdn.crate.io/downloads/releases/crate-0.55.0.tar.gz'
+    >>> uri = 'https://cdn.crate.io/downloads/releases/crate-1.0.2.tar.gz'
     >>> tmpdir = tempfile.mkdtemp()
     >>> layer = CrateLayer.from_uri(
     ...             uri, name='crate-uri', http_port=42203, directory=tmpdir)
     >>> layer.setUp()
-    >>> os.path.exists(os.path.join(tmpdir, 'crate-0.55.0'))
+    >>> os.path.exists(os.path.join(tmpdir, 'crate-1.0.2'))
     True
 
     >>> layer.tearDown()
 
-    >>> os.path.exists(os.path.join(tmpdir, 'crate-0.55.0'))
+    >>> os.path.exists(os.path.join(tmpdir, 'crate-1.0.2'))
     False

--- a/versions.cfg
+++ b/versions.cfg
@@ -1,5 +1,5 @@
 [versions]
-crate_server = 1.0.0
+crate_server = 1.0.2
 
 flake8 = 2.5.1
 mccabe = 0.3.1


### PR DESCRIPTION
which is deprecated and will be removed in newer crate versions.