### PR TITLE
renames `BlobsDisabledException` to `BlobLocationNotFoundException`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for crate
 Unreleased
 ==========
 
+ - Raise more meaningful `BlobLocationNotFoundException` error when
+   trying to upload a file to an invalid blob table.
+
+
 2017/02/17 0.19.0
 =================
 

--- a/src/crate/client/exceptions.py
+++ b/src/crate/client/exceptions.py
@@ -87,8 +87,10 @@ class BlobException(Exception):
 class DigestNotFoundException(BlobException):
     pass
 
-class BlobsDisabledException(BlobException):
+
+class BlobLocationNotFoundException(BlobException):
     pass
+
 
 class TimezoneUnawareException(Error):
     pass

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -41,7 +41,7 @@ from crate.client.exceptions import (
     ConnectionError,
     DigestNotFoundException,
     ProgrammingError,
-    BlobsDisabledException,
+    BlobLocationNotFoundException,
 )
 
 
@@ -328,7 +328,7 @@ class Client(object):
             # blob exists
             return False
         if response.status in (400, 404):
-            raise BlobsDisabledException(table, digest)
+            raise BlobLocationNotFoundException(table, digest)
         _raise_for_status(response)
 
     def blob_del(self, table, digest):

--- a/src/crate/client/http.txt
+++ b/src/crate/client/http.txt
@@ -153,7 +153,7 @@ Uploading a blob to a table with disabled blob support throws an exception::
     ...     'locations', '040f06fd774092478d450774f5ba30c5da78acc8', f)
     Traceback (most recent call last):
     ...
-    BlobsDisabledException: locations/040f06fd774092478d450774f5ba30c5da78acc8
+    BlobLocationNotFoundException: locations/040f06fd774092478d450774f5ba30c5da78acc8
 
 Error Handling
 ==============

--- a/src/crate/client/tests.py
+++ b/src/crate/client/tests.py
@@ -273,8 +273,8 @@ def test_suite():
          "ConnectionError:"),
         (re.compile(r"crate.client.exceptions.DigestNotFoundException:"),
          "DigestNotFoundException:"),
-        (re.compile(r"crate.client.exceptions.BlobsDisabledException:"),
-         "BlobsDisabledException:"),
+        (re.compile(r"crate.client.exceptions.BlobLocationNotFoundException:"),
+         "BlobLocationNotFoundException:"),
         (re.compile(r"<type "),
          "<class "),
     ])


### PR DESCRIPTION
This exception will be raised not only if the table is not a blob table
but also if the table does not exists at all.
The old exception name was wrong for the later situation.