### PR TITLE
Spawn a thread to consume the stdout

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crate
 Unreleased
 ==========
 
+ - Testing: Prevent the process.stdout buffer from filling up in the test layer 
+   which in turn would cause the process to block 
+
  - Raise more meaningful `BlobLocationNotFoundException` error when
    trying to upload a file to an invalid blob table.
 


### PR DESCRIPTION
The stdout pipe buffer is limited (and the size varies across systems). We try to read the crate http url from the startup logs (which is rather weird, shouldn't we be using the default port?) and that is our only consumer for the stdout. 

We encountered a problem with this when we tried to switch crate logging to debug. As considerably more log statements (than the default WARNING level we currently use in tests) are issued the pipe buffer overflows. 

As a solution to this, we spawn a thread that consumes the pipe buffer. 