### PR TITLE
Prepare release 0.19.1

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crate
 Unreleased
 ==========
 
+2017/02/27 0.19.1
+=================
+
  - Testing: Prevent the process.stdout buffer from filling up in the test layer 
    which in turn would cause the process to block 
 

--- a/src/crate/client/__init__.py
+++ b/src/crate/client/__init__.py
@@ -24,7 +24,7 @@ from .exceptions import Error
 
 # version string read from setup.py using a regex. Take care not to break the
 # regex!
-__version__ = "0.19.0"
+__version__ = "0.19.1"
 
 apilevel = "2.0"
 threadsafety = 2


### PR DESCRIPTION
Release changes: 

 - Testing: Prevent the process.stdout buffer from filling up in the test layer
   which in turn would cause the process to block
 - Raise more meaningful `BlobLocationNotFoundException` error when
   trying to upload a file to an invalid blob table.