### PR TITLE
Prepare release 0.19.2

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crate
 Unreleased
 ==========
 
+2017/04/28 0.19.2
+=================
+
  - Output logs in test-layer in case when CrateDB instance does not start in
    time.
 

--- a/src/crate/client/__init__.py
+++ b/src/crate/client/__init__.py
@@ -24,7 +24,7 @@ from .exceptions import Error
 
 # version string read from setup.py using a regex. Take care not to break the
 # regex!
-__version__ = "0.19.1"
+__version__ = "0.19.2"
 
 apilevel = "2.0"
 threadsafety = 2


### PR DESCRIPTION
Release changes:
 - Output logs in test-layer in case when CrateDB instance does not start in
   time.
 - Increased the default timeout for the test-layer startup to avoid timeouts 
   on slow hosts.
