### PR TITLE
Add python_requires entry to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -74,6 +74,7 @@ setup(
               'zc.customdoctests>=1.0.1'],
         sqlalchemy=['sqlalchemy>=1.0.0']
     ),
+    python_requires='>=2.7',
     install_requires=requirements,
     package_data={'': ['*.txt']},
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ import re
 
 
 requirements = [
-    'setuptools',
     'urllib3>=1.9',
     'six'
 ]


### PR DESCRIPTION
This will allow us to drop support for python 2.7 in future version. People
using python 2.7 and a recent version of `pip` will then simply get the old
version. (Instead of the newest, which would likely fail)