### PR TITLE
Fix deprecation warnings

### DIFF
--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -104,7 +104,7 @@ class Server(object):
                 **kwargs):
         """Send a request
 
-        Always set the Content-Length header.
+        Always set the Content-Length and the Content-Type header.
         """
         if headers is None:
             headers = {}
@@ -115,6 +115,7 @@ class Server(object):
         if 'X-User' not in headers and username is not None:
             headers['X-User'] = username
         headers['Accept'] = 'application/json'
+        headers['Content-Type'] = 'application/json'
         kwargs['assert_same_host'] = False
         kwargs['redirect'] = False
         kwargs['retries'] = Retry(read=0)
@@ -281,7 +282,7 @@ class Client(object):
 
         self.path = self.SQL_PATH
         if error_trace:
-            self.path += '?error_trace=1'
+            self.path += '?error_trace=true'
 
     def close(self):
         for server in self.server_pool.values():

--- a/src/crate/client/test_http.py
+++ b/src/crate/client/test_http.py
@@ -400,7 +400,7 @@ class ParamsTest(TestCase):
         from six.moves.urllib.parse import urlparse, parse_qs
         parsed = urlparse(client.path)
         params = parse_qs(parsed.query)
-        self.assertEquals(params["error_trace"], ["1"])
+        self.assertEquals(params["error_trace"], ["true"])
         client.close()
 
     def test_no_params(self):


### PR DESCRIPTION
The new Crate version uses ES 5.4.3 which logs these warnings for every REST request:

```
[WARN ][o.e.d.r.RestController   ] Content type detection for rest requests is deprecated. Specify the content type using the [Content-Type] header.
[WARN ][o.e.d.r.RestRequest      ] Expected a boolean [true/false] for request parameter [error_trace] but got [1]
```