### PR TITLE
Add actual response in case of a falsely encoded response

### DIFF
--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -137,8 +137,8 @@ def _json_from_response(response):
         return json.loads(six.text_type(response.data, 'utf-8'))
     except ValueError:
         raise ProgrammingError(
-            "Invalid server response of content-type '%s'" %
-            response.headers.get("content-type", "unknown"))
+            "Invalid server response of content-type '{}':\n{}"
+            .format(response.headers.get("content-type", "unknown"), response.data))
 
 
 def _blob_path(table, digest):


### PR DESCRIPTION
We have been throwing some errors here but finding out the root cause is hard
without the actual response.