### PR TITLE
Send username also with 'X-User' to keep backwards compatibility.

### DIFF
--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -114,11 +114,18 @@ class Server(object):
             length = super_len(data)
             if length is not None:
                 headers['Content-Length'] = length
-        if 'Authorization' not in headers and username is not None:
-            credentials = username + ':'
-            if (password is not None):
-                credentials += password
-            headers['Authorization'] = 'Basic %s' % b64encode(credentials.encode('utf-8')).decode('utf-8')
+
+        # Authentication credentials
+        if username is not None:
+            if 'Authorization' not in headers and username is not None:
+                credentials = username + ':'
+                if (password is not None):
+                    credentials += password
+                headers['Authorization'] = 'Basic %s' % b64encode(credentials.encode('utf-8')).decode('utf-8')
+            # For backwards compatibility with Crate <= 2.2
+            if 'X-User' not in headers:
+                headers['X-User'] = username
+
         headers['Accept'] = 'application/json'
         headers['Content-Type'] = 'application/json'
         kwargs['assert_same_host'] = False

--- a/src/crate/client/test_http.py
+++ b/src/crate/client/test_http.py
@@ -452,6 +452,11 @@ class RetryRequestHandler(BaseHTTPServer.BaseHTTPRequestHandler):
         else:
             self.server.SHARED['username'] = None
 
+        if self.headers['X-User'] is not None:
+            self.server.SHARED['usernameFromXUser'] = self.headers['X-User']
+        else:
+            self.server.SHARED['usernameFromXUser'] = None
+
 
 class TestingHTTPServer(BaseHTTPServer.HTTPServer):
     """
@@ -460,6 +465,7 @@ class TestingHTTPServer(BaseHTTPServer.HTTPServer):
     manager = multiprocessing.Manager()
     SHARED = manager.dict()
     SHARED['count'] = 0
+    SHARED['usernameFromXUser'] = None
     SHARED['username'] = None
     SHARED['password'] = None
 
@@ -519,6 +525,7 @@ class TestUsernameSentAsHeader(TestCase):
             self.clientWithoutUsername.sql("select * from fake")
         except ConnectionError:
             pass
+        self.assertEqual(TestingHTTPServer.SHARED['usernameFromXUser'], None)
         self.assertEqual(TestingHTTPServer.SHARED['username'], None)
         self.assertEqual(TestingHTTPServer.SHARED['password'], None)
 
@@ -526,6 +533,7 @@ class TestUsernameSentAsHeader(TestCase):
             self.clientWithUsername.sql("select * from fake")
         except ConnectionError:
             pass
+        self.assertEqual(TestingHTTPServer.SHARED['usernameFromXUser'], 'testDBUser')
         self.assertEqual(TestingHTTPServer.SHARED['username'], 'testDBUser')
         self.assertEqual(TestingHTTPServer.SHARED['password'], None)
 
@@ -533,5 +541,6 @@ class TestUsernameSentAsHeader(TestCase):
             self.clientWithUsernameAndPassword.sql("select * from fake")
         except ConnectionError:
             pass
+        self.assertEqual(TestingHTTPServer.SHARED['usernameFromXUser'], 'testDBUser')
         self.assertEqual(TestingHTTPServer.SHARED['username'], 'testDBUser')
         self.assertEqual(TestingHTTPServer.SHARED['password'], 'test:password')


### PR DESCRIPTION
Followup of b260d36aa7a03e89a737450d8560fc39af260c2c.