### PR TITLE
changed dev version to get rid of warning when installing from checkout

### DIFF
--- a/src/crate/client/__init__.py
+++ b/src/crate/client/__init__.py
@@ -24,7 +24,7 @@ from .exceptions import Error
 
 # version string read from setup.py using a regex. Take care not to break the
 # regex!
-__version__ = "0.22-dev"
+__version__ = "0.22.0.dev0"
 
 apilevel = "2.0"
 threadsafety = 2


### PR DESCRIPTION
The warning was:

```
.../crate-python/env/lib/python3.6/site-packages/setuptools/dist.py:333: UserWarning: Normalizing '0.22-dev' to '0.22.dev0'
```