### PR TITLE
testing: search for exising CA bundle file

### DIFF
--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -215,6 +215,9 @@ def _to_server_list(servers):
 
 def _pool_kw_args(verify_ssl_cert, ca_cert, client_cert, client_key):
     ca_cert = ca_cert or os.environ.get('REQUESTS_CA_BUNDLE', None)
+    if ca_cert and not os.path.exists(ca_cert):
+        # Sanity check
+        raise IOError('CA bundle file "{}" does not exist.'.format(ca_cert))
     return {
         'ca_certs': ca_cert,
         'cert_reqs': ssl.CERT_REQUIRED if verify_ssl_cert else ssl.CERT_NONE,

--- a/src/crate/client/test_http.py
+++ b/src/crate/client/test_http.py
@@ -37,12 +37,14 @@ import datetime as dt
 import urllib3.exceptions
 from base64 import b64decode
 from urllib.parse import urlparse, parse_qs
+from setuptools.ssl_support import find_ca_bundle
 
 from .http import Client, _remove_certs_for_non_https
 from .exceptions import ConnectionError, ProgrammingError
 
 
 REQUEST = 'crate.client.http.Server.request'
+CA_CERT_PATH = find_ca_bundle()
 
 
 def fake_request(response=None):
@@ -412,14 +414,16 @@ class ParamsTest(TestCase):
 
 class RequestsCaBundleTest(TestCase):
 
+
     def test_open_client(self):
-        os.environ["REQUESTS_CA_BUNDLE"] = "/etc/ssl/certs/ca-certificates.crt"
+        os.environ["REQUESTS_CA_BUNDLE"] = CA_CERT_PATH
         try:
             Client('http://127.0.0.1:4200')
         except ProgrammingError:
             self.fail("HTTP not working with REQUESTS_CA_BUNDLE")
         finally:
             os.unsetenv('REQUESTS_CA_BUNDLE')
+            os.environ["REQUESTS_CA_BUNDLE"] = ''
 
     def test_remove_certs_for_non_https(self):
         d = _remove_certs_for_non_https('https', {"ca_certs": 1})


### PR DESCRIPTION
this fixes the failing RequestsCaBundleTest when run on systems that
have a different path to the CA bundle file than /etc/ssl/certs/ca-certificates.crt