### PR TITLE
Set watermark.flood_stage to avoid config parsing failure

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,11 @@ Unreleased
    If you are using crate with Python 2.7 or 3.3 already, you will not be able
    to install newer versions of this package.
 
+ - BREAKING: In the testing layer, the custom setting of
+ `cluster.routing.allocation.disk.watermark.low` (1b) and
+ `cluster.routing.allocation.disk.watermark.high` (1b) has been removed.
+ These now default to 85% and 90%, respectively.
+
 2018/01/03 0.21.1
 =================
 

--- a/src/crate/testing/layer.py
+++ b/src/crate/testing/layer.py
@@ -260,8 +260,6 @@ class CrateLayer(object):
                         further_settings=None):
         settings = {
             "discovery.type": "zen",
-            "cluster.routing.allocation.disk.watermark.low": "1b",
-            "cluster.routing.allocation.disk.watermark.high": "1b",
             "discovery.initial_state_timeout": 0,
             "node.name": node_name,
             "cluster.name": cluster_name,


### PR DESCRIPTION
In ES 6 you can either specify a unit (e.g. bytes) or a percentage of the disk
size. If you mix the two, you'll get an error.