### PR TITLE
added configuration for docs sitemap

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,9 +10,12 @@ Unreleased
    to install newer versions of this package.
 
  - BREAKING: In the testing layer, the custom setting of
- `cluster.routing.allocation.disk.watermark.low` (1b) and
- `cluster.routing.allocation.disk.watermark.high` (1b) has been removed.
- These now default to 85% and 90%, respectively.
+   `cluster.routing.allocation.disk.watermark.low` (1b) and
+   `cluster.routing.allocation.disk.watermark.high` (1b) has been removed.
+   These now default to 85% and 90%, respectively.
+
+ - Added configuration for the sphinx_sitemap extension which allows to 
+   create a sitemap.xml from the documentation.
 
 2018/01/03 0.21.1
 =================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,2 +1,5 @@
 from crate.theme.rtd.conf.crate_python import *
 html_favicon = None
+
+site_url = 'https://crate.io/docs/clients/python/en/latest/'
+extensions = ['sphinx_sitemap']


### PR DESCRIPTION
* in the newest crate-docs-theme release we added a dependency on `sphinx_sitemap`
* added base url and the extension to build the sitemap in the crate python docs