### PR TITLE
Remove pre-installed setuptools in Travis environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,9 @@ addons:
 before_install:
   # clean existing dependencies to avoid clashes
   - pip freeze | xargs pip uninstall -y
-  - pip install --upgrade setuptools
+  - pip uninstall -y setuptools
 install:
+  - pip freeze
   - python bootstrap.py
   - sed -ir "s/SQLAlchemy.*/SQLAlchemy = ${SA_VERSION}/g" versions.cfg
   - bin/buildout -c base.cfg


### PR DESCRIPTION
Failing tests caused by pre-installed setuptools: https://travis-ci.org/crate/crash/jobs/356952953#L530
Probably related: https://github.com/travis-ci/travis-ci/issues/3220

Please merge before https://github.com/crate/crate-python/pull/282