### PR TITLE
added schema keyword argument to connect() method

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for crate
 Unreleased
 ==========
 
+- The client now allows to define a different default schema when connecting to
+  CrateDB with the ``schema`` keyword argument. This causes all statements and
+  queries that do not specify a schema explicitly to use the provided schema.
+
 - BREAKING: Dropped support for Python 2.7 and 3.3
   If you are using crate with Python 2.7 or 3.3 already, you will not be able
   to install newer versions of this package.

--- a/docs/client.txt
+++ b/docs/client.txt
@@ -61,6 +61,15 @@ also need to provide ``password`` as argument for the ``connect()`` call::
     ...                             username='me',
     ...                             password='my_secret_pw')
 
+Default Schema
+--------------
+
+To connect to CrateDB and use a different default schema than ``doc``, you can
+provide the ``schema`` keyword argument in the ``connect()`` method, like so::
+
+    >>> connection = client.connect([crate_host],
+    ...                             schema='custom_schema')
+
 Inserting Data
 ==============
 

--- a/src/crate/client/connection.py
+++ b/src/crate/client/connection.py
@@ -27,9 +27,11 @@ from distutils.version import StrictVersion
 
 
 class Connection(object):
+
     def __init__(self, servers=None, timeout=None, client=None,
                  verify_ssl_cert=False, ca_cert=None, error_trace=False,
-                 cert_file=None, key_file=None, username=None, password=None):
+                 cert_file=None, key_file=None, username=None, password=None,
+                 schema=None):
         if client:
             self.client = client
         else:
@@ -41,7 +43,8 @@ class Connection(object):
                                  cert_file=cert_file,
                                  key_file=key_file,
                                  username=username,
-                                 password=password)
+                                 password=password,
+                                 schema=schema)
         self.lowest_server_version = self._lowest_server_version()
         self._closed = False
 
@@ -107,7 +110,8 @@ def connect(servers=None,
             cert_file=None,
             key_file=None,
             username=None,
-            password=None):
+            password=None,
+            schema=None):
     """ Create a :class:Connection object
 
     :param servers:
@@ -149,4 +153,5 @@ def connect(servers=None,
                       cert_file=cert_file,
                       key_file=key_file,
                       username=username,
-                      password=password)
+                      password=password,
+                      schema=schema)

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -99,6 +99,7 @@ class Server(object):
                 headers=None,
                 username=None,
                 password=None,
+                schema=None,
                 **kwargs):
         """Send a request
 
@@ -122,6 +123,8 @@ class Server(object):
             if 'X-User' not in headers:
                 headers['X-User'] = username
 
+        if schema is not None:
+            headers['Default-Schema'] = schema
         headers['Accept'] = 'application/json'
         headers['Content-Type'] = 'application/json'
         kwargs['assert_same_host'] = False
@@ -276,7 +279,8 @@ class Client(object):
                  cert_file=None,
                  key_file=None,
                  username=None,
-                 password=None):
+                 password=None,
+                 schema=None):
         if not servers:
             servers = [self.default_server]
         else:
@@ -292,6 +296,7 @@ class Client(object):
         self._local = threading.local()
         self.username = username
         self.password = password
+        self.schema = schema
 
         self.path = self.SQL_PATH
         if error_trace:
@@ -397,7 +402,7 @@ class Client(object):
             next_server = server or self._get_server()
             try:
                 response = self.server_pool[next_server].request(
-                    method, path, username=self.username, password=self.password, **kwargs)
+                    method, path, username=self.username, password=self.password, schema=self.schema, **kwargs)
                 redirect_location = response.get_redirect_location()
                 if redirect_location and 300 <= response.status <= 308:
                     redirect_server = _server_url(redirect_location)

--- a/src/crate/client/tests.py
+++ b/src/crate/client/tests.py
@@ -51,7 +51,8 @@ from .test_http import (
     ParamsTest,
     RetryOnTimeoutServerTest,
     RequestsCaBundleTest,
-    TestUsernameSentAsHeader
+    TestUsernameSentAsHeader,
+    TestDefaultSchemaHeader,
 )
 from .sqlalchemy.tests import test_suite as sqlalchemy_test_suite
 from .sqlalchemy.types import ObjectArray
@@ -325,6 +326,7 @@ def test_suite():
     suite.addTest(unittest.makeSuite(RetryOnTimeoutServerTest))
     suite.addTest(unittest.makeSuite(RequestsCaBundleTest))
     suite.addTest(unittest.makeSuite(TestUsernameSentAsHeader))
+    suite.addTest(unittest.makeSuite(TestDefaultSchemaHeader))
     suite.addTest(sqlalchemy_test_suite())
     suite.addTest(doctest.DocTestSuite('crate.client.connection'))
     suite.addTest(doctest.DocTestSuite('crate.client.http'))


### PR DESCRIPTION
The client now allows to define a different default schema when connecting to
CrateDB with the ``schema`` keyword argument. This causes all statements and
queries that do not specify a schema explicitly to use the provided schema.