### PR TITLE
Added ability to specify chunk size when getting a blob from the blob container

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crate
 Unreleased
 ==========
 
+- Added ability to specify chunk size when getting a blob from the blob container
+
 2018/05/02 0.22.0
 =================
 

--- a/docs/blobs.txt
+++ b/docs/blobs.txt
@@ -80,6 +80,11 @@ The result is a generator object which returns one chunk per iteration::
     >>> print(next(res))
     this is the content of the file
 
+The default size of these chunks is 128 kilobytes, but this can be changed by
+using the ``get`` method and suppling the desired chunk size::
+
+    >>> res = blob_container.get('6d46af79aa5113bd7e6a67fae9ab5228648d3f81', 1024 * 128)
+
 It is also possible to check if a blob exists like this::
 
     >>> blob_container.exists('6d46af79aa5113bd7e6a67fae9ab5228648d3f81')

--- a/src/crate/client/blob.py
+++ b/src/crate/client/blob.py
@@ -70,14 +70,16 @@ class BlobContainer(object):
             return created
         return actual_digest
 
-    def get(self, digest):
+    def get(self, digest, chunk_size=1024 * 128):
         """
         Return the contents of a blob
 
         :param digest: the hex digest of the blob to return
+        :param chunk_size: the size of the chunks returned on each iteration
         :return: generator returning chunks of data
         """
-        return self.conn.client.blob_get(self.container_name, digest)
+        return self.conn.client.blob_get(self.container_name, digest,
+                                         chunk_size)
 
     def delete(self, digest):
         """


### PR DESCRIPTION
The blob size is configurable in the http client, but user has no actual access to this. This PR lets the user specify (in bytes) the size of the chunks returned by ``get``ing a blob each iteration. The default is the same as the default in the http client, 128 kilobytes.