### PR TITLE
FIX: Test layer does not close Popen

### DIFF
--- a/src/crate/testing/layer.py
+++ b/src/crate/testing/layer.py
@@ -319,6 +319,7 @@ class CrateLayer(object):
     def stop(self):
         if self.process:
             self.process.terminate()
+            self.process.__exit__(None, None, None)
         self.process = None
         self.monitor.stop()
         self._clean()


### PR DESCRIPTION
If I run the cratelayer with zope-testrunner==4.9.2, the following errors appear:

```
Tearing down left over layers:
  Tear down crate.testing.layer.crate /usr/lib/python3.7/subprocess.py:858: ResourceWarning: subprocess 4904 is still running
  ResourceWarning, source=self)
Object allocated at (most recent call last):
  File "/home/work/fund-performance/eggs/crate-0.22.1-py3.7.egg/crate/testing/layer.py", lineno 295
    stdout=subprocess.PIPE)
sys:1: ResourceWarning: unclosed file <_io.BufferedReader name=3>
```

The pull request fixes the issue.
If this is not the preferred solution, I am happy to adapt the PR.