### PR TITLE
Fix tox setup, pass required JAVA_HOME env.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist = py{py,34,35,36,37}-sa_{1_0,1_1,1_2}
 
 [testenv]
 usedevelop = True
+passenv = JAVA_HOME
 deps =
     zope.testrunner
     zope.testing


### PR DESCRIPTION
tox v2.0 introduced environment variable isolation and thus
the required `JAVA_HOME` variable must be configured to be passed
explicitly.
See https://tox.readthedocs.io/en/latest/changelog.html#v2-0-0-2015-05-12