### PR TITLE
Default JAVA_HOME env in test layer to empty string

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crate
 Unreleased
 ==========
 
+- Fixed a bug in the ``CrateLayer`` which caused ``CrateDB`` not to start up,
+  in case the ``JAVA_HOME`` environment variable was not set.
+
 2019/08/01 0.23.1
 =================
 

--- a/src/crate/testing/doctests/layer.txt
+++ b/src/crate/testing/doctests/layer.txt
@@ -134,7 +134,7 @@ Verbosity
 
 The test layer hides the standard output of Crate per default. To increase the
 verbosity level the additional keyword argument ``verbose`` needs to be set
-to ``True``.
+to ``True``::
 
     >>> layer =  CrateLayer('crate',
     ...                     crate_home=crate_path(),
@@ -150,7 +150,7 @@ Environment variables
 ---------------------
 
 It is possible to provide  enviromental variables for the ``Crate`` testing
-layer. 
+layer::
 
     >>> layer =  CrateLayer('crate',
     ...                     crate_home=crate_path(),

--- a/src/crate/testing/layer.py
+++ b/src/crate/testing/layer.py
@@ -222,7 +222,7 @@ class CrateLayer(object):
         self.verbose = verbose
         self.env = env or {}
         self.env.setdefault('CRATE_USE_IPV4', 'true')
-        self.env.setdefault('JAVA_HOME', os.environ.get('JAVA_HOME'))
+        self.env.setdefault('JAVA_HOME', os.environ.get('JAVA_HOME', ''))
         self._stdout_consumers = []
         self.conn_pool = urllib3.PoolManager(num_pools=1)
 


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This commit changes the default value for `JAVA_HOME` in the
`CrateLayer` from `None` to `''` (empty string). This is necessary,
because environment variables are always interpreted as strings, and
therefore `None` would be interpreted as a string `'None'`, which is not
a valid path for `JAVA_HOME`.

## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
