### PR TITLE
Update code for retry interval between retries

### DIFF
--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -130,7 +130,7 @@ class Server(object):
         headers['Content-Type'] = 'application/json'
         kwargs['assert_same_host'] = False
         kwargs['redirect'] = False
-        kwargs['retries'] = Retry(read=0)
+        kwargs['retries'] = Retry(read=0,backoff_factor=0.0)
         return self.pool.urlopen(
             method,
             path,


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Updated code in http.py and introduced **backoff_factor=0.0** as this parameter can do retry interval between consecutive retries. So, that when user want to change value of **backoff_factor=0.0** to 0.0,0.1,0.2 ... for retry interval they can edit value of backoff_factor as per requirement.

## Checklist

 - [ OK ] [CLA](https://crate.io/community/contribute/cla/) is signed
