### PR TITLE
 Added ``backoff_factor`` in connection to configure retry interval 

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,8 +2,11 @@
 Changes for crate
 =================
 
+
 Unreleased
 ==========
+
+- ”Added ``backoff_factor`` in connection to configure retry interval”.
 
 - Added official Python 3.8 support.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,7 @@ Changes for crate
 Unreleased
 ==========
 
-- ”Added ``backoff_factor`` in connection to configure retry interval”.
+- Added ``backoff_factor`` in connection to configure retry interval.
 
 - Added official Python 3.8 support.
 

--- a/docs/connect.txt
+++ b/docs/connect.txt
@@ -169,6 +169,19 @@ the optional ``error_trace`` argument to ``True``, like so::
 
 .. _authentication:
 
+Backoff Factor
+..............
+
+When attempting to make a request, the connection can be configured so that retries
+are made at lengthening time intervals. This can be configured like so:
+    >>>connection = client.connect(..., backoff_factor=0.1)
+
+The formula for this backoff_factor is:
+
+If ``backoff_factor`` is set to 0.1, then the delay between retries will be
+0.0, 0.1, 0.2, 0.4, 0.8, etc. The maximum backoff factor cannot exceed 120 seconds.
+By default this setting is 0, meaning that no backoff factor is present between retries.
+
 Authentication
 ==============
 

--- a/docs/connect.txt
+++ b/docs/connect.txt
@@ -173,14 +173,12 @@ Backoff Factor
 ..............
 
 When attempting to make a request, the connection can be configured so that retries
-are made at lengthening time intervals. This can be configured like so:
-    >>>connection = client.connect(..., backoff_factor=0.1)
+are made at lengthening time intervals.This can be configured like so::
 
-The formula for this backoff_factor is:
+    >>> connection = client.connect(..., backoff_factor=0.1)
 
-If ``backoff_factor`` is set to 0.1, then the delay between retries will be
-0.0, 0.1, 0.2, 0.4, 0.8, etc. The maximum backoff factor cannot exceed 120 seconds.
-By default this setting is 0, meaning that no backoff factor is present between retries.
+If ``backoff_factor``is set to 0.1,then the delay between retries will be 0.0, 0.1, 0.2,
+0.4 etc.The maximum backoff factor cannot exceed 120 seconds and by default its value is 0
 
 Authentication
 ==============

--- a/docs/connect.txt
+++ b/docs/connect.txt
@@ -173,23 +173,12 @@ Backoff Factor
 ..............
 
 When attempting to make a request, the connection can be configured so that retries
-<<<<<<< HEAD
 are made at lengthening time intervals.This can be configured like so::
 
     >>> connection = client.connect(..., backoff_factor=0.1)
 
 If ``backoff_factor``is set to 0.1,then the delay between retries will be 0.0, 0.1, 0.2,
 0.4 etc.The maximum backoff factor cannot exceed 120 seconds and by default its value is 0
-=======
-are made at lengthening time intervals. This can be configured like so:
-    >>>connection = client.connect(..., backoff_factor=0.1)
-
-The formula for this backoff_factor is:
-
-If ``backoff_factor`` is set to 0.1, then the delay between retries will be
-0.0, 0.1, 0.2, 0.4, 0.8, etc. The maximum backoff factor cannot exceed 120 seconds.
-By default this setting is 0, meaning that no backoff factor is present between retries.
->>>>>>> 40400d9e652745304131b802b6c2a5efcb188629
 
 Authentication
 ==============

--- a/src/crate/client/connection.py
+++ b/src/crate/client/connection.py
@@ -27,8 +27,8 @@ from distutils.version import StrictVersion
 
 
 class Connection(object):
-
-    def __init__(self, servers=None, timeout=None, client=None,
+  
+    def __init__(self, servers=None, timeout=None, backoff_factor=0, client=None,
                  verify_ssl_cert=False, ca_cert=None, error_trace=False,
                  cert_file=None, key_file=None, username=None, password=None,
                  schema=None):
@@ -37,6 +37,7 @@ class Connection(object):
         else:
             self.client = Client(servers,
                                  timeout=timeout,
+                                 backoff_factor=backoff_factor,
                                  verify_ssl_cert=verify_ssl_cert,
                                  ca_cert=ca_cert,
                                  error_trace=error_trace,
@@ -103,6 +104,7 @@ class Connection(object):
 
 def connect(servers=None,
             timeout=None,
+            backoff_factor=0,
             client=None,
             verify_ssl_cert=False,
             ca_cert=None,
@@ -146,6 +148,7 @@ def connect(servers=None,
     """
     return Connection(servers=servers,
                       timeout=timeout,
+                      backoff_factor=backoff_factor,
                       client=client,
                       verify_ssl_cert=verify_ssl_cert,
                       ca_cert=ca_cert,

--- a/src/crate/client/connection.py
+++ b/src/crate/client/connection.py
@@ -142,7 +142,9 @@ def connect(servers=None,
         the username in the database.
     :param password:
         the password of the user in the database.
-
+    :param backoff_factor:
+        (optional)
+        define the retry interval for unreachable servers in seconds
     >>> connect(['host1:4200', 'host2:4200'])
     <Connection <Client ['http://host1:4200', 'http://host2:4200']>>
     """


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Fix for Issue #339 in which new parameter **backoff_factor** is introduced for retry interval between consecutive retries which can be used to configure value of **backoff_factor** for other application in which crateDb is used.

## Checklist

 - [ Ok ] [CLA](https://crate.io/community/contribute/cla/) is signed
