### PR TITLE
inserted driver for solving issue #348

### DIFF
--- a/src/crate/client/sqlalchemy/dialect.py
+++ b/src/crate/client/sqlalchemy/dialect.py
@@ -159,6 +159,7 @@ colspecs = {
 
 class CrateDialect(default.DefaultDialect):
     name = 'crate'
+    driver = 'crate-python'
     statement_compiler = CrateCompiler
     ddl_compiler = CrateDDLCompiler
     type_compiler = CrateTypeCompiler


### PR DESCRIPTION
Using SQL-Alchemy needs the attribute driver.
I simply added `crate-python` as the driver name.

This solves https://github.com/crate/crate-python/issues/348

## Summary of the changes / Why this is an improvement
Added Driver Attribute, which is needed for sqlalchemy

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
