### PR TITLE
Add support for RETURNING in SQLAlchemy dialect

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,12 @@ Changes for crate
 Unreleased
 ==========
 
+- Added support for the ``RETURNING`` clause to the SQLAlchemy dialect. This
+  requires CrateDB 4.2 or greater. In case you use any server side generated
+  columns in your primary key constraint with earlier CrateDB versions, you can
+  turn this feature off by passing ``implicit_returning=False`` in the
+  ``create_engine()`` call.
+
 - Added support for ``geo_point`` and ``geo_json`` types to the SQLAlchemy
   dialect.
 

--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -177,6 +177,13 @@ class CrateCompiler(compiler.SQLCompiler):
             self.process(element.right, **kw)
         )
 
+    def returning_clause(self, stmt, returning_cols):
+        columns = [
+            self._label_select_column(None, c, True, False, {})
+            for c in sa.sql.expression._select_iterables(returning_cols)
+        ]
+        return "RETURNING " + ", ".join(columns)
+
     def visit_insert(self, insert_stmt, asfrom=False, **kw):
         """
         used to compile <sql.expression.Insert> expressions.

--- a/src/crate/client/sqlalchemy/dialect.py
+++ b/src/crate/client/sqlalchemy/dialect.py
@@ -165,6 +165,7 @@ class CrateDialect(default.DefaultDialect):
     type_compiler = CrateTypeCompiler
     supports_native_boolean = True
     colspecs = colspecs
+    implicit_returning = True
 
     def __init__(self, *args, **kwargs):
         super(CrateDialect, self).__init__(*args, **kwargs)


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Example:

```python
import random

from sqlalchemy import create_engine, inspect, func, Column, String, DateTime
from sqlalchemy.ext.declarative import declarative_base
from sqlalchemy.orm import sessionmaker
from sqlalchemy.schema import FetchedValue

engine = create_engine(
    "crate://",
    connect_args={
        "username": "crate",
    },
)
Session = sessionmaker(bind=engine)
Base = declarative_base(bind=engine)

class Log(Base):
    __tablename__ = "logs"
    __table_args__ = {"schema": "doc"}
    __mapper_args__ = {"exclude_properties": ["id"]}

    id = Column("_id", String, server_default=FetchedValue(), primary_key=True)
    ts = Column(DateTime, server_default=func.current_timestamp())
    level = Column(String)
    message = Column(String)

if __name__ == "__main__":
    o = Log(level="info", message="Hello World")
    session = Session()
    session.add(o)
    session.commit()

    print(f"{o.id=}, {o.ts=}, {o.level=}, {o.message=}")
```