### PR TITLE
Make connection pool size configurable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crate
 Unreleased
 ==========
 
+- Propagate connect parameter ``pool_size`` to urllib3 as ``maxsize`` parameter
+  in order to make the connection pool size configurable.
+
 2020/08/05 0.25.0
 =================
 

--- a/src/crate/client/connection.py
+++ b/src/crate/client/connection.py
@@ -28,10 +28,20 @@ from distutils.version import StrictVersion
 
 class Connection(object):
 
-    def __init__(self, servers=None, timeout=None, backoff_factor=0, client=None,
-                 verify_ssl_cert=False, ca_cert=None, error_trace=False,
-                 cert_file=None, key_file=None, username=None, password=None,
-                 schema=None):
+    def __init__(self,
+                 servers=None,
+                 timeout=None,
+                 backoff_factor=0,
+                 client=None,
+                 verify_ssl_cert=False,
+                 ca_cert=None,
+                 error_trace=False,
+                 cert_file=None,
+                 key_file=None,
+                 username=None,
+                 password=None,
+                 schema=None,
+                 pool_size=None):
         if client:
             self.client = client
         else:
@@ -45,7 +55,8 @@ class Connection(object):
                                  key_file=key_file,
                                  username=username,
                                  password=password,
-                                 schema=schema)
+                                 schema=schema,
+                                 pool_size=pool_size)
         self.lowest_server_version = self._lowest_server_version()
         self._closed = False
 
@@ -113,7 +124,8 @@ def connect(servers=None,
             key_file=None,
             username=None,
             password=None,
-            schema=None):
+            schema=None,
+            pool_size=None):
     """ Create a :class:Connection object
 
     :param servers:
@@ -122,6 +134,9 @@ def connect(servers=None,
     :param timeout:
         (optional)
         define the retry timeout for unreachable servers in seconds
+    :param backoff_factor:
+        (optional)
+        define the retry interval for unreachable servers in seconds
     :param client:
         (optional - for testing)
         client used to communicate with crate.
@@ -142,15 +157,17 @@ def connect(servers=None,
         the username in the database.
     :param password:
         the password of the user in the database.
-    :param backoff_factor:
+    :param pool_size:
         (optional)
-        define the retry interval for unreachable servers in seconds
+        Number of connections to save that can be reused.
+        More than 1 is useful in multithreaded situations.
     >>> connect(['host1:4200', 'host2:4200'])
     <Connection <Client ['http://host1:4200', 'http://host2:4200']>>
     """
     return Connection(servers=servers,
                       timeout=timeout,
                       backoff_factor=backoff_factor,
+                      pool_size=pool_size,
                       client=client,
                       verify_ssl_cert=verify_ssl_cert,
                       ca_cert=ca_cert,

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -283,7 +283,8 @@ class Client(object):
                  key_file=None,
                  username=None,
                  password=None,
-                 schema=None):
+                 schema=None,
+                 pool_size=None):
         if not servers:
             servers = [self.default_server]
         else:
@@ -292,6 +293,8 @@ class Client(object):
         self._inactive_servers = []
         pool_kw = _pool_kw_args(verify_ssl_cert, ca_cert, cert_file, key_file)
         pool_kw['timeout'] = timeout
+        if pool_size is not None:
+            pool_kw['maxsize'] = pool_size
         self.backoff_factor = backoff_factor
         self.server_pool = {}
         self._update_server_pool(servers, **pool_kw)


### PR DESCRIPTION
Hi there,

we have been observing several warnings like these on our live environments:
```
WARNING  [urllib3.connectionpool          ] Connection pool is full, discarding connection: testdrive.cratedb.example.net
```

## Reproduction
In order to reproduce these conveniently, you might want to use [`crate-parallel.py`](https://gist.github.com/amotl/575aae129beb17b120b848e7632365dc). It will invoke `SELECT 1;` 100 times in parallel on 10 worker threads and will immediately trigger these warnings. When invoked with the `--pool` parameter - essentially emulating this PR - everything goes along without warnings.

## Background
We found out that the [default pool size of `urllib3` is just "1"](https://github.com/urllib3/urllib3/blob/1.25.10/src/urllib3/connectionpool.py#L178), while with the [`requests` module, it is "10" already](https://github.com/psf/requests/blob/v2.24.0/requests/adapters.py#L50).

## Mitigation
- This update makes the connection pool size configurable, which is important in multi-threaded situations.
- `client.connect()` will accept a new parameter `pool_size` and will propagate it to urllib3 as `maxsize` parameter.
- ~While "urllib3" used a default of 1, the new default is now 10, following the default of the "requests" module.~

With kind regards,
Andreas.