### PR TITLE
Enable TCP keep alive on socket level

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,13 @@ Changes for crate
 Unreleased
 ==========
 
+- Enabled TCP keepalive on socket level and support for setting socket options
+  when creating the connection. The supported options are:
+
+  - ``TCP_KEEPIDLE`` (overriding ``net.ipv4.tcp_keepalive_time``)
+  - ``TCP_KEEPINTVL`` (overriding ``net.ipv4.tcp_keepalive_intvl``)
+  - ``TCP_KEEPCNT`` (overriding ``net.ipv4.tcp_keepalive_probes``)
+
 - Propagate connect parameter ``pool_size`` to urllib3 as ``maxsize`` parameter
   in order to make the connection pool size configurable.
 

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -167,19 +167,50 @@ the optional ``error_trace`` argument to ``True``, like so::
 
     >>> connection = client.connect(..., error_trace=True)
 
-.. _authentication:
-
 Backoff Factor
-..............
+--------------
 
 When attempting to make a request, the connection can be configured so that
 retries are made in increasing time intervals. This can be configured like so::
 
     >>> connection = client.connect(..., backoff_factor=0.1)
 
-If ``backoff_factor``is set to 0.1, then the delay between retries will be 0.0,
+If ``backoff_factor`` is set to 0.1, then the delay between retries will be 0.0,
 0.1, 0.2, 0.4 etc. The maximum backoff factor cannot exceed 120 seconds and by
 default its value is 0.
+
+Socket Options
+--------------
+
+Creating connections uses `urllib3 default socket options`_ but additionally
+enables TCP keepalive by setting ``socket.SO_KEEPALIVE`` to ``1``.
+
+Keepalive can be disabled using the ``socket_keepalive`` argument, like so::
+
+    >>> connection = client.connect(..., socket_keepalive=False)
+
+If keepalive is enabled (default), there are three additional, optional socket
+options that can be configured via connection arguments.
+
+:``socket_tcp_keepidle``:
+
+    Set the ``TCP_KEEPIDLE`` socket option, which overrides
+    ``net.ipv4.tcp_keepalive_time`` kernel setting if ``socket_keepalive`` is
+    ``True``.
+
+:``socket_tcp_keepintvl``:
+
+    Set the ``TCP_KEEPINTVL`` socket option, which overrides
+    ``net.ipv4.tcp_keepalive_intvl`` kernel setting if ``socket_keepalive`` is
+    ``True``.
+
+:``socket_tcp_keepcnt``:
+
+    Set the ``TCP_KEEPCNT`` socket option, which overrides
+    ``net.ipv4.tcp_keepalive_probes`` kernel setting if ``socket_keepalive`` is
+    ``True``.
+
+.. _authentication:
 
 Authentication
 ==============
@@ -247,3 +278,4 @@ Once you're connected, you can :ref:`query CrateDB <query>`.
 .. _socket timeout: https://docs.python.org/2/library/socket.html#socket.getdefaulttimeout
 .. _SQLAlchemy: http://www.sqlalchemy.org/
 .. _tracebacks: https://docs.python.org/3/library/traceback.html
+.. _urllib3 default socket options: https://urllib3.readthedocs.io/en/latest/reference/urllib3.connection.html#urllib3.connection.HTTPConnection

--- a/src/crate/client/__init__.py
+++ b/src/crate/client/__init__.py
@@ -19,7 +19,7 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-from .connection import connect
+from .connection import Connection as connect
 from .exceptions import Error
 
 __all__ = [

--- a/src/crate/client/connection.py
+++ b/src/crate/client/connection.py
@@ -41,7 +41,65 @@ class Connection(object):
                  username=None,
                  password=None,
                  schema=None,
-                 pool_size=None):
+                 pool_size=None,
+                 socket_keepalive=True,
+                 socket_tcp_keepidle=None,
+                 socket_tcp_keepintvl=None,
+                 socket_tcp_keepcnt=None,
+                 ):
+        """
+        :param servers:
+            either a string in the form of '<hostname>:<port>'
+            or a list of servers in the form of ['<hostname>:<port>', '...']
+        :param timeout:
+            (optional)
+            define the retry timeout for unreachable servers in seconds
+        :param backoff_factor:
+            (optional)
+            define the retry interval for unreachable servers in seconds
+        :param client:
+            (optional - for testing)
+            client used to communicate with crate.
+        :param verify_ssl_cert:
+            if set to ``True`` verify the servers SSL server certificate.
+            defaults to ``False``
+        :param ca_cert:
+            a path to a CA certificate to use when verifying the SSL server
+            certificate.
+        :param error_trace:
+            if set to ``True`` return a whole stacktrace of any server error if
+            one occurs
+        :param cert_file:
+            a path to the client certificate to present to the server.
+        :param key_file:
+            a path to the client key to use when communicating with the server.
+        :param username:
+            the username in the database.
+        :param password:
+            the password of the user in the database.
+        :param pool_size:
+            (optional)
+            Number of connections to save that can be reused.
+            More than 1 is useful in multithreaded situations.
+        :param socket_keepalive:
+            (optional, defaults to ``True``)
+            Enable TCP keepalive on socket level.
+        :param socket_tcp_keepidle:
+            (optional)
+            Set the ``TCP_KEEPIDLE`` socket option, which overrides
+            ``net.ipv4.tcp_keepalive_time`` kernel setting if ``socket_keepalive``
+            is ``True``.
+        :param socket_tcp_keepintvl:
+            (optional)
+            Set the ``TCP_KEEPINTVL`` socket option, which overrides
+            ``net.ipv4.tcp_keepalive_intvl`` kernel setting if ``socket_keepalive``
+            is ``True``.
+        :param socket_tcp_keepcnt:
+            (optional)
+            Set the ``TCP_KEEPCNT`` socket option, which overrides
+            ``net.ipv4.tcp_keepalive_probes`` kernel setting if ``socket_keepalive``
+            is ``True``.
+        """
         if client:
             self.client = client
         else:
@@ -56,7 +114,12 @@ class Connection(object):
                                  username=username,
                                  password=password,
                                  schema=schema,
-                                 pool_size=pool_size)
+                                 pool_size=pool_size,
+                                 socket_keepalive=socket_keepalive,
+                                 socket_tcp_keepidle=socket_tcp_keepidle,
+                                 socket_tcp_keepintvl=socket_tcp_keepintvl,
+                                 socket_tcp_keepcnt=socket_tcp_keepcnt,
+                                 )
         self.lowest_server_version = self._lowest_server_version()
         self._closed = False
 
@@ -113,67 +176,5 @@ class Connection(object):
         self.close()
 
 
-def connect(servers=None,
-            timeout=None,
-            backoff_factor=0,
-            client=None,
-            verify_ssl_cert=False,
-            ca_cert=None,
-            error_trace=False,
-            cert_file=None,
-            key_file=None,
-            username=None,
-            password=None,
-            schema=None,
-            pool_size=None):
-    """ Create a :class:Connection object
-
-    :param servers:
-        either a string in the form of '<hostname>:<port>'
-        or a list of servers in the form of ['<hostname>:<port>', '...']
-    :param timeout:
-        (optional)
-        define the retry timeout for unreachable servers in seconds
-    :param backoff_factor:
-        (optional)
-        define the retry interval for unreachable servers in seconds
-    :param client:
-        (optional - for testing)
-        client used to communicate with crate.
-    :param verify_ssl_cert:
-        if set to ``True`` verify the servers SSL server certificate.
-        defaults to ``False``
-    :param ca_cert:
-        a path to a CA certificate to use when verifying the SSL server
-        certificate.
-    :param error_trace:
-        if set to ``True`` return a whole stacktrace of any server error if
-        one occurs
-    :param cert_file:
-        a path to the client certificate to present to the server.
-    :param key_file:
-        a path to the client key to use when communicating with the server.
-    :param username:
-        the username in the database.
-    :param password:
-        the password of the user in the database.
-    :param pool_size:
-        (optional)
-        Number of connections to save that can be reused.
-        More than 1 is useful in multithreaded situations.
-    >>> connect(['host1:4200', 'host2:4200'])
-    <Connection <Client ['http://host1:4200', 'http://host2:4200']>>
-    """
-    return Connection(servers=servers,
-                      timeout=timeout,
-                      backoff_factor=backoff_factor,
-                      pool_size=pool_size,
-                      client=client,
-                      verify_ssl_cert=verify_ssl_cert,
-                      ca_cert=ca_cert,
-                      error_trace=error_trace,
-                      cert_file=cert_file,
-                      key_file=key_file,
-                      username=username,
-                      password=password,
-                      schema=schema)
+# For backwards compatibility and not to break existing imports
+connect = Connection

--- a/src/crate/client/doctests/blob.txt
+++ b/src/crate/client/doctests/blob.txt
@@ -7,7 +7,7 @@ bloba API.
 
 Create a connection::
 
-    >>> from crate.client.connection import connect
+    >>> from crate.client import connect
     >>> client = connect([crate_host])
 
 Get a blob container::

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -20,28 +20,37 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 
+import calendar
 import heapq
+import io
 import json
 import logging
 import os
-import io
+import re
+import socket
 import ssl
-import urllib3
-import urllib3.exceptions
-from urllib3.util.retry import Retry
+import threading
+from urllib.parse import urlparse
 from base64 import b64encode
 from time import time
 from datetime import datetime, date
 from decimal import Decimal
-import calendar
-import threading
-import re
-from urllib.parse import urlparse
+from urllib3 import connection_from_url
+from urllib3.connection import HTTPConnection
+from urllib3.exceptions import (
+    HTTPError,
+    MaxRetryError,
+    ProtocolError,
+    ProxyError,
+    ReadTimeoutError,
+    SSLError,
+)
+from urllib3.util.retry import Retry
 from crate.client.exceptions import (
     ConnectionError,
+    BlobLocationNotFoundException,
     DigestNotFoundException,
     ProgrammingError,
-    BlobLocationNotFoundException,
 )
 
 
@@ -90,7 +99,17 @@ class CrateJsonEncoder(json.JSONEncoder):
 class Server(object):
 
     def __init__(self, server, **pool_kw):
-        self.pool = urllib3.connection_from_url(server, **pool_kw)
+        socket_options = _get_socket_opts(
+            pool_kw.pop('socket_keepalive', False),
+            pool_kw.pop('socket_tcp_keepidle', None),
+            pool_kw.pop('socket_tcp_keepintvl', None),
+            pool_kw.pop('socket_tcp_keepcnt', None),
+        )
+        self.pool = connection_from_url(
+            server,
+            socket_options=socket_options,
+            **pool_kw,
+        )
 
     def request(self,
                 method,
@@ -218,17 +237,23 @@ def _to_server_list(servers):
     return [_server_url(s) for s in servers]
 
 
-def _pool_kw_args(verify_ssl_cert, ca_cert, client_cert, client_key):
+def _pool_kw_args(verify_ssl_cert, ca_cert, client_cert, client_key,
+                  timeout=None, pool_size=None):
     ca_cert = ca_cert or os.environ.get('REQUESTS_CA_BUNDLE', None)
     if ca_cert and not os.path.exists(ca_cert):
         # Sanity check
         raise IOError('CA bundle file "{}" does not exist.'.format(ca_cert))
-    return {
+
+    kw = {
         'ca_certs': ca_cert,
         'cert_reqs': ssl.CERT_REQUIRED if verify_ssl_cert else ssl.CERT_NONE,
         'cert_file': client_cert,
         'key_file': client_key,
+        'timeout': timeout,
     }
+    if pool_size is not None:
+        kw['maxsize'] = pool_size
+    return kw
 
 
 def _remove_certs_for_non_https(server, kwargs):
@@ -258,6 +283,33 @@ def _create_sql_payload(stmt, args, bulk_args):
     return json.dumps(data, cls=CrateJsonEncoder)
 
 
+def _get_socket_opts(keepalive=True,
+                     tcp_keepidle=None,
+                     tcp_keepintvl=None,
+                     tcp_keepcnt=None):
+    """
+    Return an optional list of socket options for urllib3's HTTPConnection
+    constructor.
+    """
+    if not keepalive:
+        return None
+
+    # always use TCP keepalive
+    opts = [(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)]
+
+    # hasattr check because some of the options depend on system capabilities
+    # see https://docs.python.org/3/library/socket.html#socket.SOMAXCONN
+    if hasattr(socket, 'TCP_KEEPIDLE') and tcp_keepidle is not None:
+        opts.append((socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, tcp_keepidle))
+    if hasattr(socket, 'TCP_KEEPINTVL') and tcp_keepintvl is not None:
+        opts.append((socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, tcp_keepintvl))
+    if hasattr(socket, 'TCP_KEEPCNT') and tcp_keepcnt is not None:
+        opts.append((socket.IPPROTO_TCP, socket.TCP_KEEPCNT, tcp_keepcnt))
+
+    # additionally use urllib3's default socket options
+    return HTTPConnection.default_socket_options + opts
+
+
 class Client(object):
     """
     Crate connection client using crate's HTTP API.
@@ -284,17 +336,27 @@ class Client(object):
                  username=None,
                  password=None,
                  schema=None,
-                 pool_size=None):
+                 pool_size=None,
+                 socket_keepalive=True,
+                 socket_tcp_keepidle=None,
+                 socket_tcp_keepintvl=None,
+                 socket_tcp_keepcnt=None,
+                 ):
         if not servers:
             servers = [self.default_server]
         else:
             servers = _to_server_list(servers)
         self._active_servers = servers
         self._inactive_servers = []
-        pool_kw = _pool_kw_args(verify_ssl_cert, ca_cert, cert_file, key_file)
-        pool_kw['timeout'] = timeout
-        if pool_size is not None:
-            pool_kw['maxsize'] = pool_size
+        pool_kw = _pool_kw_args(
+            verify_ssl_cert, ca_cert, cert_file, key_file, timeout, pool_size,
+        )
+        pool_kw.update({
+            'socket_keepalive': socket_keepalive,
+            'socket_tcp_keepidle': socket_tcp_keepidle,
+            'socket_tcp_keepintvl': socket_tcp_keepintvl,
+            'socket_tcp_keepcnt': socket_tcp_keepcnt,
+        })
         self.backoff_factor = backoff_factor
         self.server_pool = {}
         self._update_server_pool(servers, **pool_kw)
@@ -429,18 +491,18 @@ class Client(object):
                         self._drop_server(next_server, response.reason)
                 else:
                     return response
-            except (urllib3.exceptions.MaxRetryError,
-                    urllib3.exceptions.ReadTimeoutError,
-                    urllib3.exceptions.SSLError,
-                    urllib3.exceptions.HTTPError,
-                    urllib3.exceptions.ProxyError,) as ex:
+            except (MaxRetryError,
+                    ReadTimeoutError,
+                    SSLError,
+                    HTTPError,
+                    ProxyError,) as ex:
                 ex_message = _ex_to_message(ex)
                 if server:
                     raise ConnectionError(
                         "Server not available, exception: %s" % ex_message
                     )
                 preserve_server = False
-                if isinstance(ex, urllib3.exceptions.ProtocolError):
+                if isinstance(ex, ProtocolError):
                     preserve_server = any(
                         t in [type(arg) for arg in ex.args]
                         for t in PRESERVE_ACTIVE_SERVER_EXCEPTIONS


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

`urllib3` allows to set socket options for individual connections.

Reference: https://urllib3.readthedocs.io/en/latest/reference/urllib3.connection.html#urllib3.connection.HTTPConnection

This should help mitigating problems with environments where idle connections are closed without resetting. This happens e.g. with Azure load balancers.

Reference: https://joonas.fi/2017/01/23/microsoft-azures-networking-is-fundamentally-broken/


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
 - [x] Add documentation about socket options
