### PR TITLE
Add github action to release project to pypi on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+---
+name: release
+
+on: push
+
+jobs:
+  pypi:
+    name: Build & publish package to pypi
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.ref, 'refs/tags')
+    steps:
+      - uses: actions/checkout@master
+
+      - name: Set up python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Build package
+        run: |
+          python -m pip install twine wheel
+          python setup.py sdist bdist_wheel
+          twine check dist/*.tar.gz
+
+      - name: Publish package
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -59,7 +59,8 @@ In the release branch:
 
 - Push to origin/<release_branch>
 
-- Create a tag by running ``./devtools/create_tag.sh``
+- Create a tag by running ``./devtools/create_tag.sh``. This will trigger a
+  Github action which releases the new version to PyPi.
 
 On master:
 
@@ -67,39 +68,7 @@ On master:
 
 Next:
 
-- Deploy to PyPI (see section below)
-
 - Archive docs for old releases (see section below)
-
-PyPI Deployment
----------------
-
-To create the package use::
-
-    $ bin/py setup.py sdist bdist_wheel
-
-Then, use twine_ to upload the package to PyPI_::
-
-    $ bin/twine upload dist/*
-
-For this to work, you will need a personal PyPI account that is set up as a project admin.
-
-You'll also need to create a ``~/.pypirc`` file, like so::
-
-    [distutils]
-    index-servers =
-      pypi
-
-    [pypi]
-    repository=https://pypi.python.org/pypi
-    username=<USERNAME>
-    password=<PASSWORD>
-
-Here, ``<USERNAME>`` and ``<PASSWORD>`` should be replaced with your username and password, respectively.
-
-If you want to check the PyPI description before uploading, run::
-
-    $ bin/py setup.py check --strict --restructuredtext
 
 Archiving Docs Versions
 -----------------------


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

This replaces the manual release of the Crate python driver to PyPi to one done by Github actions, triggered on tag pushes, similar to our Crash project. The pypi API key has already been added to the secrets for this project.

Addresses #378 