### PR TITLE
Attempt to fix CI with Python 3.9

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
         crate-version: [nightly]
         os: [ubuntu-latest]
         sqla-version: ['1.1.15', '1.2.18', '1.3.17']
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:
       - uses: actions/checkout@master

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crate
 Unreleased
 ==========
 
+- Added official Python 3.9 support.
+
 2020/09/28 0.26.0
 =================
 

--- a/setup.py
+++ b/setup.py
@@ -83,6 +83,7 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Database'

--- a/versions.cfg
+++ b/versions.cfg
@@ -60,7 +60,7 @@ zope.interface = 4.1.1
 
 # Required by:
 # zc.recipe.testrunner==2.0.0
-zope.testrunner = 4.4.3
+zope.testrunner = 4.9.1
 gp.recipe.tox = 0.4
 
 requests = 2.5.0


### PR DESCRIPTION
This tries to fix `AttributeError: '_MainThread' object has no attribute 'isAlive'` CI was croaking on after adding support for Python 3.9, see also https://github.com/crate/crate-python/pull/380#issuecomment-714452850.
