### PR TITLE
Fix failing https.txt test

### DIFF
--- a/src/crate/client/doctests/https.txt
+++ b/src/crate/client/doctests/https.txt
@@ -76,7 +76,7 @@ certificate and key file.
 Below an example, in this case it fails because the supplied certificate is
 invalid::
 
-    >>> client = HttpClient([crate_host], cert_file=invalid_ca_cert, key_file=invalid_ca_cert)
+    >>> client = HttpClient([crate_host], cert_file=invalid_ca_cert, key_file=invalid_ca_cert, verify_ssl_cert=True)
     >>> client.server_infos(crate_host)
     Traceback (most recent call last):
     ...


### PR DESCRIPTION
This error occurs in some python version tests but not in others - I believe the actual exception message differs across different library versions, but the outcome is ultimately the same.