### PR TITLE
Test against more recent SQLAlchemy versions on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
       matrix:
         crate-version: [nightly]
         os: [ubuntu-latest]
-        sqla-version: ['1.1.15', '1.2.18', '1.3.17']
+        sqla-version: ['1.1.18', '1.2.19', '1.3.20']
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:


### PR DESCRIPTION
This just bumps to the most recent releases of the 1.1, 1.2 and 1.3 series of SQLAlchemy.
