### PR TITLE
Datetime format

### DIFF
--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -315,7 +315,7 @@ class Client(object):
     Crate connection client using crate's HTTP API.
     """
 
-    SQL_PATH = '/_sql'
+    SQL_PATH = '/_sql?types'
     """Crate URI path for issuing SQL statements."""
 
     retry_interval = 30

--- a/src/crate/client/sqlalchemy/dialect.py
+++ b/src/crate/client/sqlalchemy/dialect.py
@@ -43,6 +43,7 @@ TYPES_MAP = {
     "smallint": sqltypes.SmallInteger,
     "timestamp": sqltypes.TIMESTAMP,
     "timestamp with time zone": sqltypes.TIMESTAMP,
+    "timestamp without time zone": sqltypes.TIMESTAMP,
     "object": Object,
     "integer": sqltypes.Integer,
     "long": sqltypes.NUMERIC,
@@ -64,6 +65,7 @@ try:
     TYPES_MAP["smallint_array"] = ARRAY(sqltypes.SmallInteger)
     TYPES_MAP["timestamp_array"] = ARRAY(sqltypes.TIMESTAMP)
     TYPES_MAP["timestamp with time zone_array"] = ARRAY(sqltypes.TIMESTAMP)
+    TYPES_MAP["timestamp without time zone_array"] = ARRAY(sqltypes.TIMESTAMP)
     TYPES_MAP["long_array"] = ARRAY(sqltypes.NUMERIC)
     TYPES_MAP["bigint_array"] = ARRAY(sqltypes.NUMERIC)
     TYPES_MAP["double_array"] = ARRAY(sqltypes.DECIMAL)
@@ -74,7 +76,6 @@ try:
     TYPES_MAP["text_array"] = ARRAY(sqltypes.String)
 except Exception:
     pass
-
 
 log = logging.getLogger(__name__)
 
@@ -261,7 +262,7 @@ class CrateDialect(default.DefaultDialect):
 
             def result_fun(result):
                 rows = result.fetchall()
-                return set(map(lambda el: el[0], rows))
+                return list(set(map(lambda el: el[0], rows)))
         else:
             query = """SELECT constraint_name
                    FROM information_schema.table_constraints


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Changing the return type from set to list on get_pk_constraint(), solves a compatibility issue from Apache Superset that doesn't show the metadata from CrateDB tables in the SQL Lab.

CrateDB types TIMESTAMP and TIMESTAMP WITHOUT TIME ZONE, are returned as python datetime objects, correctly displaying date columns in charts and SQL Lab from Apache Superset.


## Checklist

 - [x ] [CLA](https://crate.io/community/contribute/cla/) is signed
