### PR TITLE
Adjust badges, bump SQLAlchemy test version and add "workflow_dispatch"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,19 +1,19 @@
----
-name: test
+name: Tests
 
 on:
-  pull_request: ~
   push:
-    branches:
-      - master
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  workflow_dispatch:
   schedule:
     - cron: '0 2 * * *'
 
 
 jobs:
   test:
-    name: "Test python-${{ matrix.python-version }}
-     sqla: ${{ matrix.sqla-version }}
+    name: "Python: ${{ matrix.python-version }}
+     SQLA: ${{ matrix.sqla-version }}
      CrateDB: ${{ matrix.crate-version }}
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
@@ -21,7 +21,7 @@ jobs:
       matrix:
         crate-version: [nightly]
         os: [ubuntu-latest]
-        sqla-version: ['1.1.18', '1.2.19', '1.3.20']
+        sqla-version: ['1.1.18', '1.2.19', '1.3.23']
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
 
     steps:

--- a/README.rst
+++ b/README.rst
@@ -2,29 +2,42 @@
 CrateDB Python Client
 =====================
 
-.. image:: https://dev.azure.com/cratedb/crate-python/_apis/build/status/crate.crate-python?branchName=master
-   :target: https://dev.azure.com/cratedb/crate-python/_build/latest?definitionId=2&branchName=master
-   :alt: Azure Pipeline
-
-.. image:: https://img.shields.io/pypi/v/crate.svg
-   :target: https://pypi.python.org/pypi/crate/
-   :alt: PyPI Version
-
-.. image:: https://img.shields.io/pypi/pyversions/crate.svg
-   :target: https://pypi.python.org/pypi/crate/
-   :alt: Python Version
-
-.. image:: https://img.shields.io/pypi/dw/crate.svg
-    :target: https://pypi.python.org/pypi/crate/
-    :alt: PyPI Downloads
-
-.. image:: https://img.shields.io/pypi/wheel/crate.svg
-    :target: https://pypi.python.org/pypi/crate/
-    :alt: Wheel
+.. image:: https://github.com/crate/crate-python/workflows/Tests/badge.svg
+    :target: https://github.com/crate/crate-python/actions?workflow=Tests
+    :alt: Build status
 
 .. image:: https://coveralls.io/repos/github/crate/crate-python/badge.svg?branch=master
     :target: https://coveralls.io/github/crate/crate-python?branch=master
     :alt: Coverage
+
+.. image:: https://readthedocs.org/projects/crate-python/badge/
+    :target: https://crate.io/docs/python/
+    :alt: Build status (documentation)
+
+.. image:: https://img.shields.io/pypi/v/crate.svg
+    :target: https://pypi.org/project/crate/
+    :alt: PyPI Version
+
+.. image:: https://img.shields.io/pypi/pyversions/crate.svg
+    :target: https://pypi.org/project/crate/
+    :alt: Python Version
+
+.. image:: https://img.shields.io/pypi/dw/crate.svg
+    :target: https://pypi.org/project/crate/
+    :alt: PyPI Downloads
+
+.. image:: https://img.shields.io/pypi/wheel/crate.svg
+    :target: https://pypi.org/project/crate/
+    :alt: Wheel
+
+.. image:: https://img.shields.io/pypi/status/crate.svg
+    :target: https://pypi.org/project/crate/
+    :alt: Status
+
+.. image:: https://img.shields.io/pypi/l/crate.svg
+    :target: https://pypi.org/project/crate/
+    :alt: License
+
 
 |
 


### PR DESCRIPTION
Hi there,

this is just a minor update which refreshes the badges displayed within README.rst. However, its main purpose was to investigate why CI tests would not run on #395.

- Adjust and add some badges to README.rst.
- For covering the most recent SQLAlchemy 1.3 release, bump CI to use SQLAlchemy version 1.3.23.
- Also, enable listening to `workflow_dispatch` events in order to be able to trigger workflows manually from the UI.

With kind regards,
Andreas.
