### PR TITLE
Improve test suite

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,9 @@ setup(
         ]
     },
     extras_require=dict(
-        test=['zope.testing',
-              'zc.customdoctests>=1.0.1'],
+        test=['zope.testing>=4,<5',
+              'zc.customdoctests>=1.0.1,<2',
+              'stopit>=1.1.2,<2'],
         sqlalchemy=['sqlalchemy>=1.0,<1.4', 'geojson>=2.5.0']
     ),
     python_requires='>=3.4',

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -544,8 +544,8 @@ class Client(object):
                                        (ts, server, message))
                     else:
                         self._active_servers.append(server)
-                        logger.warn("Restored server %s into active pool",
-                                    server)
+                        logger.warning("Restored server %s into active pool",
+                                       server)
 
             # if none is old enough, use oldest
             if not self._active_servers:

--- a/src/crate/client/tests.py
+++ b/src/crate/client/tests.py
@@ -110,6 +110,7 @@ crate_transport_port = 44309
 local = '127.0.0.1'
 crate_host = "{host}:{port}".format(host=local, port=crate_port)
 crate_uri = "http://%s" % crate_host
+crate_layer = None
 
 
 def ensure_cratedb_layer():
@@ -213,7 +214,7 @@ def setUpCrateLayerAndSqlAlchemy(test):
     test.globs['CrateDialect'] = CrateDialect
 
 
-class HttpsTestServerLayer(object):
+class HttpsTestServerLayer:
     PORT = 65534
     HOST = "localhost"
     CERT_FILE = os.path.abspath(os.path.join(os.path.dirname(__file__),
@@ -241,11 +242,11 @@ class HttpsTestServerLayer(object):
 
         def do_GET(self):
             self.send_response(200)
-            self.send_header("Content-Length", len(self.payload))
+            payload = self.payload.encode('UTF-8')
+            self.send_header("Content-Length", len(payload))
             self.send_header("Content-Type", "application/json; charset=UTF-8")
             self.end_headers()
-            self.wfile.write(self.payload.encode('UTF-8'))
-            return
+            self.wfile.write(payload)
 
     def __init__(self):
         self.server = self.HttpsServer(
@@ -257,7 +258,7 @@ class HttpsTestServerLayer(object):
         thread = threading.Thread(target=self.serve_forever)
         thread.daemon = True  # quit interpreter when only thread exists
         thread.start()
-        time.sleep(1)
+        time.sleep(0.5)
 
     def serve_forever(self):
         print("listening on", self.HOST, self.PORT)

--- a/src/crate/client/tests.py
+++ b/src/crate/client/tests.py
@@ -108,15 +108,21 @@ settings = {
 crate_port = 44209
 crate_transport_port = 44309
 local = '127.0.0.1'
-crate_layer = CrateLayer('crate',
-                         crate_home=crate_path(),
-                         port=crate_port,
-                         host=local,
-                         transport_port=crate_transport_port,
-                         settings=settings)
-
 crate_host = "{host}:{port}".format(host=local, port=crate_port)
 crate_uri = "http://%s" % crate_host
+
+
+def ensure_cratedb_layer():
+    global crate_layer
+
+    if crate_layer is None:
+        crate_layer = CrateLayer('crate',
+                                 crate_home=crate_path(),
+                                 port=crate_port,
+                                 host=local,
+                                 transport_port=crate_transport_port,
+                                 settings=settings)
+    return crate_layer
 
 
 def refresh(table):
@@ -348,7 +354,7 @@ def test_suite():
         optionflags=flags,
         encoding='utf-8'
     )
-    s.layer = crate_layer
+    s.layer = ensure_cratedb_layer()
     suite.addTest(s)
 
     s = doctest.DocFileSuite(
@@ -362,7 +368,7 @@ def test_suite():
         optionflags=flags,
         encoding='utf-8'
     )
-    s.layer = crate_layer
+    s.layer = ensure_cratedb_layer()
     suite.addTest(s)
 
     s = doctest.DocFileSuite(
@@ -372,7 +378,7 @@ def test_suite():
         optionflags=flags,
         encoding='utf-8'
     )
-    s.layer = crate_layer
+    s.layer = ensure_cratedb_layer()
     suite.addTest(s)
 
     return suite

--- a/src/crate/client/tests.py
+++ b/src/crate/client/tests.py
@@ -117,6 +117,19 @@ crate_layer = None
 
 
 def ensure_cratedb_layer():
+    """
+    In order to skip individual tests by manually disabling them within
+    `def test_suite()`, it is crucial make the test layer not run on each
+    and every occasion. So, things like this will be possible::
+
+        ./bin/test -vvvv --ignore_dir=testing
+
+    TODO: Through a subsequent patch, the possibility to individually
+          unselect specific tests might be added to `def test_suite()`
+          on behalf of environment variables.
+          A blueprint for this kind of logic can be found at
+          https://github.com/crate/crate/commit/414cd833.
+    """
     global crate_layer
 
     if crate_layer is None:

--- a/versions.cfg
+++ b/versions.cfg
@@ -24,6 +24,7 @@ zc.customdoctests = 1.0.1
 zc.recipe.egg = 2.0.7
 zc.recipe.testrunner = 2.2
 zope.testing = 4.9
+stopit = 1.1.2
 
 # Required by:
 # clint==0.5.1


### PR DESCRIPTION
Hi there,

based on this patch, it becomes easier to selectively run parts of the test suite. This is important to me because the whole test suite is currently only able to be invoked exclusively on Linux.

With kind regards,
Andreas.