### PR TITLE
Close urllib3 pool before swapping the server into the "inactive" list

### DIFF
--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -568,6 +568,15 @@ class Client(object):
         """
         Drop server from active list and adds it to the inactive ones.
         """
+
+        # Try to close resource first.
+        try:
+            self.server_pool[server].close()
+        except Exception as ex:
+            logger.warning("When removing server from active pool, "
+                           "resource could not be closed: %s", ex)
+
+        # Apply bookkeeping.
         try:
             self._active_servers.remove(server)
         except ValueError:
@@ -576,7 +585,7 @@ class Client(object):
             heapq.heappush(self._inactive_servers, (time(), server, message))
             logger.warning("Removed server %s from active pool", server)
 
-        # if this is the last server raise exception, otherwise try next
+        # If this is the last server, raise an exception.
         if not self._active_servers:
             raise ConnectionError(
                 ("No more Servers available, "

--- a/src/crate/client/test_http.py
+++ b/src/crate/client/test_http.py
@@ -310,7 +310,7 @@ class ThreadSafeHttpClientTest(TestCase):
 
     def setUp(self):
         self.client = Client(self.servers)
-        self.client.retry_interval = 0.1  # faster retry
+        self.client.retry_interval = 0.2  # faster retry
 
     def tearDown(self):
         self.client.close()


### PR DESCRIPTION
Hi there,

while working on the test suite, I found a glitch, maybe unnoticed more often than not, where active connections have not been closed before removing them from the list of active servers.

With kind regards,
Andreas.
