### PR TITLE
Tests: Explicitly set multiprocessing start method to "fork"

### DIFF
--- a/src/crate/client/test_http.py
+++ b/src/crate/client/test_http.py
@@ -29,10 +29,10 @@ import queue
 import random
 import traceback
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from multiprocessing.context import ForkProcess
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 from threading import Thread, Event
-from multiprocessing import Process
 from decimal import Decimal
 import datetime as dt
 import urllib3.exceptions
@@ -396,7 +396,7 @@ class KeepAliveClientTest(TestCase):
 
     def __init__(self, *args, **kwargs):
         super(KeepAliveClientTest, self).__init__(*args, **kwargs)
-        self.server_process = Process(target=self._run_server)
+        self.server_process = ForkProcess(target=self._run_server)
 
     def setUp(self):
         super(KeepAliveClientTest, self).setUp()
@@ -529,8 +529,8 @@ class TestingHttpServerTestCase(TestCase):
         super().__init__(*args, **kwargs)
         self.assertIsNotNone(self.request_handler)
         self.server_address = ('127.0.0.1', random.randint(65000, 65535))
-        self.server_process = Process(target=TestingHTTPServer.run_server,
-                                      args=(self.server_address, self.request_handler))
+        self.server_process = ForkProcess(target=TestingHTTPServer.run_server,
+                                          args=(self.server_address, self.request_handler))
 
     def setUp(self):
         self.server_process.start()


### PR DESCRIPTION
Hi there,

because @mfussenegger said at https://github.com/crate/crate-python/pull/386#discussion_r514057300:
> I'm not keen on building workarounds for problems that should be solved.

this patch provides a better alternative than #386, as it tries to tackle the underlying root cause of one detail which made the testsuite croak on macOS. Specifically, it resolves #398.

By using multiprocessing's ForkProcess, the testsuite will also start working on macOS again, even on Python 3.8+.

The background on this is that beginning with Python 3.8+, "fork" is not the default on all platforms anymore but has been changed to "spawn" on macOS. This method, however, apparently is not compatible with how multiprocessing is currently used within the test harness.

With kind regards,
Andreas.