### PR TITLE
Documentation: Add link checker to CI and fix broken links

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: docs
+
+on:
+  workflow_dispatch:
+  pull_request: ~
+  push:
+    branches:
+      - master
+  schedule:
+    - cron: '0 7 * * *'
+
+jobs:
+  documentation:
+
+    name: Run link checker
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Acquire sources
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Build docs
+        run: |
+          cd docs && make check

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -1,0 +1,1 @@
+.crate-docs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,159 @@
+# Licensed to Crate (https://crate.io) under one or more contributor license
+# agreements.  See the NOTICE file distributed with this work for additional
+# information regarding copyright ownership.  Crate licenses this file to you
+# under the Apache License, Version 2.0 (the "License"); you may not use this
+# file except in compliance with the License.  You may obtain a copy of the
+# License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# However, if you have executed another commercial license agreement with Crate
+# these terms will supersede the license and you may use the software solely
+# pursuant to the terms of the relevant commercial agreement.
+
+
+# =============================================================================
+# Crate Docs
+# =============================================================================
+
+# The Crate Docs project provides a common set of tools for producing the
+# Crate.io documentation. See <https://github.com/crate/crate-docs/> for more
+# information.
+
+# This file is taken from the demo Sphinx project available at
+# <https://github.com/crate/crate-docs/blob/main/docs>. This demo docs project
+# provides a reference implementation that should be copied for all Sphinx
+# projects at Crate.io.
+
+# The Crate Docs build system works by centralizing its core components in the
+# `crate-docs` repository. At build time, this Makefile creates a copy of the
+# this project under the `.crate-docs` directory. This Makefile is an interface
+# for those core components.
+
+
+# Upgraded instructions
+# -----------------------------------------------------------------------------
+
+# You must pin your Sphinx project to a specific version of the Crate Docs
+# project. You can do this by editing the `build.json` file. Change the JSON
+# `message` value to the desired release number. A list of releases is
+# available at <https://github.com/crate/crate-docs/releases>.
+
+# Although care has been taken to restrict changes to the core components, you
+# may occasionally need to update your project to match the reference
+# implementation. Check the release notes for any special instructions.
+
+
+# Project-specific customization
+# =============================================================================
+
+# If you want to customize the build system for your Sphinx project, add lines
+# to this section.
+
+
+# Build system integration
+# =============================================================================
+
+# This is a boilerplate section is required for integration with the Crate Docs
+# build system. All Sphinx projects using a the same Crate Docs version
+# should have exactly the same boilerplate.
+
+# IF YOU ARE EDITING THIS FILE IN A REAL SPHINX PROJECT, YOU SHOULD NOT MAKE
+# ANY CHANGES TO THIS SECTION.
+
+# If you want to make changes to the boilerplate, please make a pull request on
+# the demo Sphinx project in the Crate Docs repository available at
+# <https://github.com/crate/crate-docs/blob/main/docs>.
+
+.EXPORT_ALL_VARIABLES:
+
+DOCS_DIR      := docs
+TOP_DIR       := ..
+BUILD_JSON    := build.json
+BUILD_REPO    := https://github.com/crate/crate-docs.git
+LATEST_BUILD  := https://github.com/crate/crate-docs/releases/latest
+CLONE_DIR     := .crate-docs
+SRC_DIR       := $(CLONE_DIR)/common-build
+SELF_SRC      := $(TOP_DIR)/common-build
+SELF_MAKEFILE := $(SELF_SRC)/rules.mk
+SRC_MAKE      := $(MAKE) -f $(SRC_DIR)/rules.mk
+
+# Parse the JSON file
+BUILD_VERSION := $(shell cat $(BUILD_JSON) | \
+    python -c 'import json, sys; print(json.load(sys.stdin)["message"])')
+
+ifeq ($(BUILD_VERSION),)
+$(error No build version specified in `$(BUILD_JSON)`.)
+endif
+
+# This is a non-essential check so we timeout after only two seconds so as not
+# to frustrate the user when there are network issues
+LATEST_VERSION := $(shell curl -sI --connect-timeout 2 '$(LATEST_BUILD)' | \
+    grep -i 'Location:' | grep -Eoh '[^/]+$$')
+
+# Skip if no version could be determined (i.e., because of a network error)
+ifneq ($(LATEST_VERSION),)
+# Only issue a warning if there is a version mismatch
+ifneq ($(BUILD_VERSION),$(LATEST_VERSION))
+define version_warning
+You are using Crate Docs version $(BUILD_VERSION), however version \
+$(LATEST_VERSION) is available. You should consider upgrading. Follow the \
+instructions in `Makefile` and then run `make reset`.
+endef
+endif
+endif
+
+# Default rule
+.PHONY: help
+help: $(CLONE_DIR)
+	@ $(MAKE) version-warn
+	@ $(SRC_MAKE) $@
+
+.PHONY: version-warn
+version-warn:
+	@ # Because version numbers may vary in length, we must wrap the warning
+	@ # message at run time to be sure of correct output
+	@ if test -n '$(version_warning)'; then \
+	      printf '\033[33m'; \
+	      echo '$(version_warning)' | fold -w 79 -s; \
+	      printf '\033[00m\n'; \
+	  fi
+
+ifneq ($(wildcard $(SELF_MAKEFILE)),)
+# The project detects itself and fakes an install of its own core build rules
+# so that it can test itself
+$(CLONE_DIR):
+	@ printf '\033[1mInstalling the build system...\033[00m\n'
+	@ mkdir -p $@
+	@ cp -R $(SELF_SRC) $(SRC_DIR)
+	@ printf 'Created: $(CLONE_DIR)\n'
+else
+# All other projects install a versioned copy of the core build rules
+$(CLONE_DIR):
+	@ printf '\033[1mInstalling the build system...\033[00m\n'
+	@ git clone --depth=1 -c advice.detachedHead=false \
+	    --branch=$(BUILD_VERSION) $(BUILD_REPO) $(CLONE_DIR)
+	@ printf 'Created: $(CLONE_DIR)\n'
+endif
+
+# Don't pass through this target
+.PHONY: Makefile
+Makefile:
+
+# By default, pass targets through to the core build rules
+.PHONY:
+%: $(CLONE_DIR)
+	@ $(MAKE) version-warn
+	@ $(SRC_MAKE) $@
+
+.PHONY: reset
+reset:
+	@ printf '\033[1mResetting the build system...\033[00m\n'
+	@ rm -rf $(CLONE_DIR)
+	@ printf 'Removed: $(CLONE_DIR)\n'

--- a/docs/appendices/compatibility.rst
+++ b/docs/appendices/compatibility.rst
@@ -202,9 +202,9 @@ Older versions
 For information about older versions of the client, consult `the 0.14.2
 changelog`_.
 
-.. _commit(): http://docs.sqlalchemy.org/en/latest/orm/session_api.html#sqlalchemy.orm.session.Session.commit
+.. _commit(): http://docs.sqlalchemy.org/en/latest/orm/session_api.html#sqlalchemy.orm.Session.commit
 .. _correlated updates: http://docs.sqlalchemy.org/en/latest/core/tutorial.html#correlated-updates
-.. _count(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.count
+.. _count(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.Query.count
 .. _create your own users: https://crate.io/docs/crate/reference/en/latest/admin/user-management.html
 .. _date: https://docs.python.org/3/library/datetime.html#date-objects
 .. _datetime: https://docs.python.org/3/library/datetime.html#datetime-objects
@@ -214,23 +214,23 @@ changelog`_.
 .. _DQL: http://docs.sqlalchemy.org/en/latest/orm/query.html
 .. _enterprise edition: https://crate.io/products/cratedb-enterprise/
 .. _eventual consistency: https://crate.io/docs/crate/guide/en/latest/architecture/storage-consistency.html
-.. _filter_by(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.filter_by
-.. _filter(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.filter
+.. _filter_by(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.Query.filter_by
+.. _filter(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.Query.filter
 .. _flush(): http://docs.sqlalchemy.org/en/latest/orm/session_basics.html#flushing
 .. _from_select(): http://docs.sqlalchemy.org/en/latest/core/dml.html#sqlalchemy.sql.expression.Insert.from_select
 .. _get_columns(): http://docs.sqlalchemy.org/en/latest/core/reflection.html#sqlalchemy.engine.reflection.Inspector.get_columns
 .. _get_pk_constraint(): http://docs.sqlalchemy.org/en/latest/core/reflection.html#sqlalchemy.engine.reflection.Inspector.get_pk_constraint
 .. _get_table_names(): http://docs.sqlalchemy.org/en/latest/core/reflection.html#sqlalchemy.engine.reflection.Inspector.get_table_names
-.. _group_by(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.group_by
+.. _group_by(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.Query.group_by
 .. _insert(): http://docs.sqlalchemy.org/en/latest/core/tutorial.html#inserts-and-updates
-.. _join(): http://docs.sqlalchemy.org/en/latest/orm/query.html?sqlalchemy.orm.query.Query.join
-.. _limit(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.limit
-.. _offset(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.offset
-.. _order_by(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.query.Query.order_by
+.. _join(): http://docs.sqlalchemy.org/en/latest/orm/query.html?sqlalchemy.orm.Query.join
+.. _limit(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.Query.limit
+.. _offset(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.Query.offset
+.. _order_by(): http://docs.sqlalchemy.org/en/latest/orm/query.html#sqlalchemy.orm.Query.order_by
 .. _PyPI: https://pypi.org/
-.. _rollback(): http://docs.sqlalchemy.org/en/latest/orm/session_api.html#sqlalchemy.orm.session.Session.rollback
+.. _rollback(): http://docs.sqlalchemy.org/en/latest/orm/session_api.html#sqlalchemy.orm.Session.rollback
 .. _Session: http://docs.sqlalchemy.org/en/latest/orm/session_api.html
-.. _subquery(): http://docs.sqlalchemy.org/en/latest/orm/query.html?sqlalchemy.orm.query.Query.subquery
+.. _subquery(): http://docs.sqlalchemy.org/en/latest/orm/query.html?sqlalchemy.orm.Query.subquery
 .. _the 0.14.2 changelog: https://github.com/crate/crate-python/blob/415ee6d1eb3de2fe55a342e57f46841b769f1d44/CHANGES.txt
 .. _types.ARRAY: http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.ARRAY
 .. _update(): http://docs.sqlalchemy.org/en/latest/core/tutorial.html#inserts-and-updates

--- a/docs/appendices/data-types.rst
+++ b/docs/appendices/data-types.rst
@@ -48,7 +48,7 @@ CrateDB       Python
 
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#boolean
 __ https://docs.python.org/3/library/stdtypes.html#boolean-values
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#string
+__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#character-data-types
 __ https://docs.python.org/3/library/stdtypes.html#str
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
 __ https://docs.python.org/3/library/functions.html#int
@@ -82,15 +82,15 @@ Python        CrateDB
 ============= ====================================
 
 __ https://docs.python.org/3/library/decimal.html
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#string
-__ https://docs.python.org/3/library/datetime.html?highlight=date#date-objects
+__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#character-data-types
+__ https://docs.python.org/3/library/datetime.html#date-objects
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#string
-__ https://docs.python.org/3/library/datetime.html?highlight=date#datetime-objects
+__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#character-data-types
+__ https://docs.python.org/3/library/datetime.html#datetime-objects
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#string
+__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#character-data-types
 
 .. NOTE::
 
@@ -131,6 +131,7 @@ CrateDB           SQLAlchemy
 `geo_shape`__     :ref:`geoshape` |nbsp| (extension type)
 ================= =========================================
 
+
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#boolean
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.Boolean
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
@@ -145,9 +146,9 @@ __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#n
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.Float
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-types
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.DECIMAL
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#timestamp
+__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#date-time-types
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.TIMESTAMP
-__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#string
+__ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#character-data-types
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.String
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#array
 __ http://docs.sqlalchemy.org/en/latest/core/type_basics.html#sqlalchemy.types.ARRAY

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,0 +1,5 @@
+{
+  "schemaVersion": 1,
+  "label": "docs build",
+  "message": "2.0.0"
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,20 @@
 from crate.theme.rtd.conf.python import *
 
+
+if "sphinx.ext.intersphinx" not in extensions:
+    extensions += ["sphinx.ext.intersphinx"]
+
+
+if "intersphinx_mapping" not in globals():
+    intersphinx_mapping = {}
+
+
+intersphinx_mapping.update({
+    'reference': ('https://crate.io/docs/crate/reference/', None),
+    'sa': ('https://docs.sqlalchemy.org/en/13/', None),
+    })
+
+
 rst_prolog = """
 .. |nbsp| unicode:: 0xA0
    :trim:

--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -60,7 +60,7 @@ for HTTP requests on port 4200, the node URL would be
    to connect to CrateDB on the local host with the default HTTP port number,
    i.e. ``http://localhost:4200/``.
 
-   So, if you're just getting started with CrateDB, the first time you connect,
+   If you're just getting started with CrateDB, the first time you connect,
    you can probably omit this argument.
 
 .. _multiple-nodes:

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -60,8 +60,8 @@ object), iPython's autocompletion, and many other features.
 Set up as a dependency
 ======================
 
-There are `many ways`_ to handle Python project dependencies. The official PyPI
-package should be compatible with all of them.
+In order to handle Python project dependencies, there are `many ways`_.
+The official PyPI package should be compatible with all of them.
 
 Next steps
 ==========

--- a/docs/sqlalchemy.rst
+++ b/docs/sqlalchemy.rst
@@ -351,8 +351,8 @@ To use these types, you can create columns, like so::
     ...    coordinate = sa.Column(types.Geopoint)
     ...    area = sa.Column(types.Geoshape)
 
-There are multiple ways of creating a geopoint. Firstly, you can define it as
-a tuple of ``(longitude, latitude)``::
+A geopoint can be created in multiple ways. Firstly, you can define it as a
+tuple of ``(longitude, latitude)``::
 
     >>> point = (139.76, 35.68)
 
@@ -618,7 +618,7 @@ column on the ``Character`` class.
 .. _dynamic values: https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#dynamic
 .. _table refresh: https://crate.io/docs/crate/reference/en/latest/general/dql/refresh.html
 .. _list: https://docs.python.org/3/library/stdtypes.html#lists
-.. _dictionaries: https://docs.python.org/3/library/stdtypes.html?highlight=lists#dict
+.. _dictionaries: https://docs.python.org/3/library/stdtypes.html#dict
 .. _UPDATE: https://crate.io/docs/crate/reference/en/latest/general/dml.html#updating-data
 .. _eq: https://docs.python.org/2/library/operator.html#operator.eq
 .. _operator: https://docs.python.org/2/library/operator.html
@@ -627,7 +627,7 @@ column on the ``Character`` class.
 .. _count result rows: http://docs.sqlalchemy.org/en/latest/orm/tutorial.html#counting
 .. _MATCH predicate: https://crate.io/docs/crate/reference/en/latest/general/dql/fulltext.html#match-predicate
 .. _arguments reference: https://crate.io/docs/crate/reference/en/latest/general/dql/fulltext.html#arguments
-.. _boost values: https://crate.io/docs/crate/reference/en/latest/general/dql/fulltext.html?highlight=fulltext#arguments
+.. _boost values: https://crate.io/docs/crate/reference/en/latest/general/dql/fulltext.html#arguments
 .. _match type: https://crate.io/docs/crate/reference/en/latest/general/dql/fulltext.html#predicates-match-types
 .. _match options: https://crate.io/docs/stable/sql/fulltext.html#options
 .. _fulltext indices reference: https://crate.io/docs/crate/reference/en/latest/general/ddl/fulltext-indices.html


### PR DESCRIPTION
Hi there,

this patch improves the state of the onion on all links within the documentation.

- Add [`crate-docs`](https://github.com/crate/crate-docs) build system.
- Run link checker earch morning.
- Rephrase a few spots in order to satisfy the Vale prose linter.

With kind regards,
Andreas.