### PR TITLE
Use Codecov instead of Coveralls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,3 +43,10 @@ jobs:
         run: |
           bin/flake8
           bin/coverage run bin/test -vv1
+          bin/coverage xml
+
+      # https://github.com/codecov/codecov-action
+      - name: Upload coverage results to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .venv*
 .coverage
+coverage.xml
 .idea/
 .installed.cfg
 .tox/

--- a/README.rst
+++ b/README.rst
@@ -6,8 +6,8 @@ CrateDB Python Client
     :target: https://github.com/crate/crate-python/actions?workflow=Tests
     :alt: Build status
 
-.. image:: https://coveralls.io/repos/github/crate/crate-python/badge.svg?branch=master
-    :target: https://coveralls.io/github/crate/crate-python?branch=master
+.. image:: https://codecov.io/gh/crate/crate-python/branch/master/graph/badge.svg
+    :target: https://app.codecov.io/gh/crate/crate-python
     :alt: Coverage
 
 .. image:: https://readthedocs.org/projects/crate-python/badge/

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+# https://docs.codecov.io/docs/common-recipe-list
+# https://docs.codecov.io/docs/commit-status#patch-status
+
+coverage:
+  status:
+    project:
+      default:
+        target: 85%    # the required coverage value
+        threshold: 3%  # the leniency in hitting the target


### PR DESCRIPTION
Hi,

Codecov can receive and process multiple coverage reports for the same job by merging them. That's why we also replaced Coveralls on both PHP repositories `crate-pdo` and `crate-dbal`.

With kind regards,
Andreas.