### PR TITLE
CI: Add push notification to nightly build runs

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,3 +36,13 @@ jobs:
         run: |
           bin/flake8
           bin/coverage run bin/test -vv1
+
+      - name: Slack Notification
+        uses: rtCamp/action-slack-notify@v2
+        env:
+          SLACK_CHANNEL: alert-engineering
+          SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
+          SLACK_MESSAGE: 'Job status was:  ${{ job.status }}'
+          SLACK_TITLE: Build outcome for crate-python
+          SLACK_USERNAME: jenkins
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
Hi there,

we wanted to check how the nightly jobs can be improved by having them send out notifications about their outcome. This is just a test cycle for investigating how this will work on GHA before converging it into a final version and rolling it out to other repositories.

With kind regards,
Andreas.