### PR TITLE
Revert "CI: Add push notification to nightly build runs"

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,13 +36,3 @@ jobs:
         run: |
           bin/flake8
           bin/coverage run bin/test -vv1
-
-      - name: Slack Notification
-        uses: rtCamp/action-slack-notify@v2
-        env:
-          SLACK_CHANNEL: alert-engineering
-          SLACK_COLOR: ${{ job.status }} # or a specific color like 'green' or '#ff00ff'
-          SLACK_MESSAGE: 'Job status was:  ${{ job.status }}'
-          SLACK_TITLE: Build outcome for crate-python
-          SLACK_USERNAME: jenkins
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
This reverts commit ce8d5e72b2d9ff7b084251ff42e61fed6bd31540. The reason is that it didn't work, see also https://github.com/crate/crate-python/pull/412#issuecomment-833466115.

I might trial this on behalf of a different repository before bringing it back in a functional way.