### PR TITLE
Use new Codecov uploader instead of the Bash Uploader

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
         python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
         cratedb-version: ['4.5.0']
         sqla-version: ['1.1.18', '1.2.19', '1.3.23']
-      fail-fast: false
+      fail-fast: true
 
     steps:
       - uses: actions/checkout@master


### PR DESCRIPTION
Hi.

this patch follows https://github.com/crate/crate/pull/11810.

After the [recent security event at Codecov](https://about.codecov.io/security-update/), they started rolling out their new uploader, see [1]. According to their deprecation plan, they are already conducting scheduled brownouts of the Bash Uploader, starting Sept 1, 2021.

As we are using the corresponding GitHub Action here, see also [2] for further deprecation notices and migration notes.

With kind regards,
Andreas.

[1] https://about.codecov.io/blog/introducing-codecovs-new-uploader/
[2] https://github.com/marketplace/actions/codecov

/cc @jayeff, @proddata, @hammerhead, @jweberpm, @SStorm 