### PR TITLE
CI: Expand build matrix for nightly test job

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: ['ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-22.04', 'macos-10.15', 'macos-11', 'macos-12']
         python-version: ['3.7', '3.8', '3.9', '3.10']
         cratedb-version: ['nightly']
         sqla-version: ['1.4.37']


### PR DESCRIPTION
We missed to detect regressions on macOS => 11 in the past. This patch goes full on with all available runners on Linux and macOS in order to improve that situation.