### PR TITLE
Documentation: Fix dependencies for version 0.23

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,1 @@
-# don't pin crate version numbers so the latest will always be pulled when you
-# set up your environment from scratch
-
-crate-docs-theme>=0.7
-
-# packages for local dev
-
-sphinx-autobuild==0.6.0
-
-# the next section should mirror the RTD environment
-
-alabaster>=0.7,<0.8,!=0.7.5
-setuptools<41
-sphinx==1.7.4
+crate-docs-theme


### PR DESCRIPTION
The documentation for CrateDB Python version 0.23 still uses an older theme. It maybe is related to the version pinning of Sphinx, which will probably make `pip` select an older version of `crate-docs-theme`.

-- https://crate.io/docs/python/en/0.23/
