### PR TITLE
Tests: Use UTC-based `utcnow().date()` instead of localtime-based `date.today()`

### DIFF
--- a/src/crate/client/sqlalchemy/doctests/itests.txt
+++ b/src/crate/client/sqlalchemy/doctests/itests.txt
@@ -105,7 +105,7 @@ aren't set when the row is inserted as there is no default method::
 
 The datetime and date can be set using a update statement::
 
-    >>> location.nullable_date = datetime.today()
+    >>> location.nullable_date = datetime.utcnow().date()
     >>> location.nullable_datetime = datetime.utcnow()
     >>> session.flush()
 

--- a/src/crate/client/tests.py
+++ b/src/crate/client/tests.py
@@ -27,7 +27,7 @@ import socket
 import unittest
 import doctest
 from pprint import pprint
-from datetime import datetime, date
+from datetime import datetime
 from http.server import HTTPServer, BaseHTTPRequestHandler
 import ssl
 import time
@@ -213,7 +213,7 @@ def setUpCrateLayerAndSqlAlchemy(test):
         __tablename__ = 'locations'
         name = sa.Column(sa.String, primary_key=True)
         kind = sa.Column(sa.String)
-        date = sa.Column(sa.Date, default=date.today)
+        date = sa.Column(sa.Date, default=lambda: datetime.utcnow().date())
         datetime_tz = sa.Column(sa.DateTime, default=datetime.utcnow)
         datetime_notz = sa.Column(sa.DateTime, default=datetime.utcnow)
         nullable_datetime = sa.Column(sa.DateTime)


### PR DESCRIPTION
### Motivation
- Hunting an occasional known fluke when running the test suite on CI after midnight.
- Further set the stage for #437.
- Back out of #440, which went too far.

### About

`datetime.date.today()` returns the current local date. So, its outcome depends on the system time zone. Because we want to use UTC-based date and time objects instead, `datetime.utcnow().date()` is a better choice.
