### PR TITLE
Improve installation documentation: Be pragmatic and tell people DWIM

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -60,13 +60,10 @@ Installation
 
 The CrateDB Python client is available as a pip_ package.
 
-To install, run::
+To install the most recent driver version, including the SQLAlchemy dialect
+extension, run::
 
-    $ pip install crate
-
-To update, run::
-
-    $ pip install --upgrade crate
+    $ pip install "crate[sqlalchemy]" --upgrade
 
 
 Contributing

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -25,11 +25,12 @@ Install
 
 The CrateDB Python client is `available`_ as a `PyPI`_ package.
 
-To install the package, run:
+To install the most recent driver version, including the SQLAlchemy dialect
+extension, run:
 
 .. code-block:: sh
 
-   sh$ pip install crate
+   sh$ pip install "crate[sqlalchemy]" --upgrade
 
 After that is done, you can import the library, like so:
 


### PR DESCRIPTION
## In a nutshell
Use that canonical command line for advertising the installation of the CrateDB Python driver.
```console
pip install "crate[sqlalchemy]" --upgrade
```

The idea is to show the user right away how to install the most recent version of the CrateDB Python driver together with its SQLAlchemy dialect extension.

We think it is a small but important change to the _installation_ sections of the documentation, which will avoid a lot of frustration for many newcomers. @rafaelasantana, @hammerhead and @proddata will love it.

## Rationale
The other way round, it will be missed by people more often than not, causing general confusion and poor experience on the first time of use.

It is intended for developer folks in general, so it is perfectly fine to tell them about the canonical `pip` incantation, including all the possible options and parameters, which has the highest chance to be copied verbatim into the terminal without further ado. This even holds true for non-developer folks.

I think anyone who intententionally _does not want to install_ that extension, will be able to easily figure out to omit the corresponding `extra`.
