### PR TITLE
GHA runners `ubuntu-18.04` and `macos-10.15` are deprecated

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-18.04', 'ubuntu-20.04', 'ubuntu-22.04', 'macos-10.15', 'macos-11', 'macos-12']
+        os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-11', 'macos-12']
         python-version: ['3.7', '3.8', '3.9', '3.10']
         cratedb-version: ['nightly']
         sqla-version: ['1.4.37']


### PR DESCRIPTION
Hi there,

the nightly job run [1] told us that GHA runners `ubuntu-18.04` and `macos-10.15` are deprecated [2,3]. This patch removes them from the list where to run the _Nightly_ jobs on.

With kind regards,
Andreas.

[1] https://github.com/crate/crate-python/actions/runs/3004766690
[2] https://github.com/actions/runner-images/issues/6002
[3] https://github.com/actions/runner-images/issues/5583