### PR TITLE
Return `TIMESTAMP` types as timezone-aware native Python `datetime` objects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,10 @@ Unreleased
 - SQLAlchemy: Added support for ``crate_index`` and ``nullable`` attributes in
   ORM column definitions.
 
+- Added support for converting ``TIMESTAMP`` columns to timezone-aware
+  ``datetime`` objects, using the new ``time_zone`` keyword argument.
+
+
 2022/12/02 0.28.0
 =================
 

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,8 @@ setup(
     install_requires=['urllib3>=1.9,<2'],
     extras_require=dict(
         sqlalchemy=['sqlalchemy>=1.0,<1.5',
-                    'geojson>=2.5.0,<3'],
+                    'geojson>=2.5.0,<3',
+                    'backports.zoneinfo<1; python_version<"3.9"'],
         test=['tox>=3,<4',
               'zope.testing>=4,<5',
               'zope.testrunner>=5,<6',

--- a/src/crate/client/converter.py
+++ b/src/crate/client/converter.py
@@ -123,6 +123,9 @@ class Converter:
 
         return convert
 
+    def set(self, type_: DataType, converter: ConverterFunction):
+        self._mappings[type_] = converter
+
 
 class DefaultTypeConverter(Converter):
     def __init__(self, more_mappings: Optional[ConverterMapping] = None) -> None:

--- a/src/crate/client/doctests/cursor.txt
+++ b/src/crate/client/doctests/cursor.txt
@@ -364,6 +364,76 @@ Proof that the converter works correctly, ``B\'0110\'`` should be converted to
     [6]
 
 
+``TIMESTAMP`` conversion with time zone
+=======================================
+
+Based on the data type converter functionality, the driver offers a convenient
+interface to make it return timezone-aware ``datetime`` objects, using the
+desired time zone.
+
+For your reference, in the following examples, epoch 1658167836758 is
+``Mon, 18 Jul 2022 18:10:36 GMT``.
+
+::
+
+    >>> import datetime
+    >>> tz_mst = datetime.timezone(datetime.timedelta(hours=7), name="MST")
+    >>> cursor = connection.cursor(time_zone=tz_mst)
+
+    >>> connection.client.set_next_response({
+    ...     "col_types": [4, 11],
+    ...     "rows":[ [ "foo", 1658167836758 ] ],
+    ...     "cols":[ "name", "timestamp" ],
+    ...     "rowcount":1,
+    ...     "duration":123
+    ... })
+
+    >>> cursor.execute('')
+
+    >>> cursor.fetchone()
+    ['foo', datetime.datetime(2022, 7, 19, 1, 10, 36, 758000, tzinfo=datetime.timezone(datetime.timedelta(seconds=25200), 'MST'))]
+
+For the ``time_zone`` keyword argument, different data types are supported.
+The available options are:
+
+- ``datetime.timezone.utc``
+- ``datetime.timezone(datetime.timedelta(hours=7), name="MST")``
+- ``pytz.timezone("Australia/Sydney")``
+- ``zoneinfo.ZoneInfo("Australia/Sydney")``
+- ``+0530`` (UTC offset in string format)
+
+Let's exercise all of them::
+
+    >>> cursor.time_zone = datetime.timezone.utc
+    >>> cursor.execute('')
+    >>> cursor.fetchone()
+    ['foo', datetime.datetime(2022, 7, 18, 18, 10, 36, 758000, tzinfo=datetime.timezone.utc)]
+
+    >>> import pytz
+    >>> cursor.time_zone = pytz.timezone("Australia/Sydney")
+    >>> cursor.execute('')
+    >>> cursor.fetchone()
+    ['foo', datetime.datetime(2022, 7, 19, 4, 10, 36, 758000, tzinfo=<DstTzInfo 'Australia/Sydney' AEST+10:00:00 STD>)]
+
+    >>> try:
+    ...     import zoneinfo
+    ... except ImportError:
+    ...     from backports import zoneinfo
+    >>> cursor.time_zone = zoneinfo.ZoneInfo("Australia/Sydney")
+    >>> cursor.execute('')
+    >>> record = cursor.fetchone()
+    >>> record
+    ['foo', datetime.datetime(2022, 7, 19, 4, 10, 36, 758000, ...zoneinfo.ZoneInfo(key='Australia/Sydney'))]
+
+    >>> record[1].tzname()
+    'AEST'
+
+    >>> cursor.time_zone = "+0530"
+    >>> cursor.execute('')
+    >>> cursor.fetchone()
+    ['foo', datetime.datetime(2022, 7, 18, 23, 40, 36, 758000, tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), '+0530'))]
+
+
 .. Hidden: close connection
 
     >>> connection.close()

--- a/src/crate/client/test_cursor.py
+++ b/src/crate/client/test_cursor.py
@@ -19,10 +19,16 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-from datetime import datetime
+import datetime
 from ipaddress import IPv4Address
 from unittest import TestCase
 from unittest.mock import MagicMock
+try:
+    import zoneinfo
+except ImportError:
+    from backports import zoneinfo
+
+import pytz
 
 from crate.client import connect
 from crate.client.converter import DataType, DefaultTypeConverter
@@ -31,6 +37,93 @@ from crate.client.test_util import ClientMocked
 
 
 class CursorTest(TestCase):
+
+    @staticmethod
+    def get_mocked_connection():
+        client = MagicMock(spec=Client)
+        return connect(client=client)
+
+    def test_create_with_timezone_as_datetime_object(self):
+        """
+        Verify the cursor returns timezone-aware `datetime` objects when requested to.
+        Switching the time zone at runtime on the cursor object is possible.
+        Here: Use a `datetime.timezone` instance.
+        """
+
+        connection = self.get_mocked_connection()
+
+        tz_mst = datetime.timezone(datetime.timedelta(hours=7), name="MST")
+        cursor = connection.cursor(time_zone=tz_mst)
+
+        self.assertEqual(cursor.time_zone.tzname(None), "MST")
+        self.assertEqual(cursor.time_zone.utcoffset(None), datetime.timedelta(seconds=25200))
+
+        cursor.time_zone = datetime.timezone.utc
+        self.assertEqual(cursor.time_zone.tzname(None), "UTC")
+        self.assertEqual(cursor.time_zone.utcoffset(None), datetime.timedelta(0))
+
+    def test_create_with_timezone_as_pytz_object(self):
+        """
+        Verify the cursor returns timezone-aware `datetime` objects when requested to.
+        Here: Use a `pytz.timezone` instance.
+        """
+        connection = self.get_mocked_connection()
+        cursor = connection.cursor(time_zone=pytz.timezone('Australia/Sydney'))
+        self.assertEqual(cursor.time_zone.tzname(None), "Australia/Sydney")
+
+        # Apparently, when using `pytz`, the timezone object does not return an offset.
+        # Nevertheless, it works, as demonstrated per doctest in `cursor.txt`.
+        self.assertEqual(cursor.time_zone.utcoffset(None), None)
+
+    def test_create_with_timezone_as_zoneinfo_object(self):
+        """
+        Verify the cursor returns timezone-aware `datetime` objects when requested to.
+        Here: Use a `zoneinfo.ZoneInfo` instance.
+        """
+        connection = self.get_mocked_connection()
+        cursor = connection.cursor(time_zone=zoneinfo.ZoneInfo('Australia/Sydney'))
+        self.assertEqual(cursor.time_zone.key, 'Australia/Sydney')
+
+    def test_create_with_timezone_as_utc_offset_success(self):
+        """
+        Verify the cursor returns timezone-aware `datetime` objects when requested to.
+        Here: Use a UTC offset in string format.
+        """
+        connection = self.get_mocked_connection()
+        cursor = connection.cursor(time_zone="+0530")
+        self.assertEqual(cursor.time_zone.tzname(None), "+0530")
+        self.assertEqual(cursor.time_zone.utcoffset(None), datetime.timedelta(seconds=19800))
+
+        connection = self.get_mocked_connection()
+        cursor = connection.cursor(time_zone="-1145")
+        self.assertEqual(cursor.time_zone.tzname(None), "-1145")
+        self.assertEqual(cursor.time_zone.utcoffset(None), datetime.timedelta(days=-1, seconds=44100))
+
+    def test_create_with_timezone_as_utc_offset_failure(self):
+        """
+        Verify the cursor croaks when trying to create it with invalid UTC offset strings.
+        """
+        connection = self.get_mocked_connection()
+        with self.assertRaises(AssertionError) as ex:
+            connection.cursor(time_zone="foobar")
+        self.assertEqual(str(ex.exception), "Time zone 'foobar' is given in invalid UTC offset format")
+
+        connection = self.get_mocked_connection()
+        with self.assertRaises(ValueError) as ex:
+            connection.cursor(time_zone="+abcd")
+        self.assertEqual(str(ex.exception), "Time zone '+abcd' is given in invalid UTC offset format: "
+                                            "invalid literal for int() with base 10: '+ab'")
+
+    def test_create_with_timezone_connection_cursor_precedence(self):
+        """
+        Verify that the time zone specified on the cursor object instance
+        takes precedence over the one specified on the connection instance.
+        """
+        client = MagicMock(spec=Client)
+        connection = connect(client=client, time_zone=pytz.timezone('Australia/Sydney'))
+        cursor = connection.cursor(time_zone="+0530")
+        self.assertEqual(cursor.time_zone.tzname(None), "+0530")
+        self.assertEqual(cursor.time_zone.utcoffset(None), datetime.timedelta(seconds=19800))
 
     def test_execute_with_args(self):
         client = MagicMock(spec=Client)
@@ -78,7 +171,7 @@ class CursorTest(TestCase):
         c.execute("")
         result = c.fetchall()
         self.assertEqual(result, [
-            ['foo', IPv4Address('10.10.10.1'), datetime(2022, 7, 18, 18, 10, 36, 758000), 6],
+            ['foo', IPv4Address('10.10.10.1'), datetime.datetime(2022, 7, 18, 18, 10, 36, 758000), 6],
             [None, None, None, None],
         ])
 
@@ -193,3 +286,56 @@ class CursorTest(TestCase):
         # ``executemany()`` is not intended to be used with statements returning result
         # sets. The result will always be empty.
         self.assertEqual(result, [])
+
+    def test_execute_with_timezone(self):
+        client = ClientMocked()
+        conn = connect(client=client)
+
+        # Create a `Cursor` object with `time_zone`.
+        tz_mst = datetime.timezone(datetime.timedelta(hours=7), name="MST")
+        c = conn.cursor(time_zone=tz_mst)
+
+        # Make up a response using CrateDB data type `TIMESTAMP`.
+        conn.client.set_next_response({
+            "col_types": [4, 11],
+            "cols": ["name", "timestamp"],
+            "rows": [
+                ["foo", 1658167836758],
+                [None, None],
+            ],
+        })
+
+        # Run execution and verify the returned `datetime` object is timezone-aware,
+        # using the designated timezone object.
+        c.execute("")
+        result = c.fetchall()
+        self.assertEqual(result, [
+            [
+                'foo',
+                datetime.datetime(2022, 7, 19, 1, 10, 36, 758000,
+                                  tzinfo=datetime.timezone(datetime.timedelta(seconds=25200), 'MST')),
+            ],
+            [
+                None,
+                None,
+            ],
+        ])
+        self.assertEqual(result[0][1].tzname(), "MST")
+
+        # Change timezone and verify the returned `datetime` object is using it.
+        c.time_zone = datetime.timezone.utc
+        c.execute("")
+        result = c.fetchall()
+        self.assertEqual(result, [
+            [
+                'foo',
+                datetime.datetime(2022, 7, 18, 18, 10, 36, 758000, tzinfo=datetime.timezone.utc),
+            ],
+            [
+                None,
+                None,
+            ],
+        ])
+        self.assertEqual(result[0][1].tzname(), "UTC")
+
+        conn.close()


### PR DESCRIPTION
### About
When requested, make the driver return timezone-aware native Python `datetime` objects for CrateDB's `TIMESTAMP` types. The user can easily supply the desired time zone by different means.

### Rationale
@mfussenegger asked at https://github.com/crate/crate-python/pull/442#pullrequestreview-1088223785:
> I think something common like setting the timezone for datetime objects could be made even easier for users.

I shared some initial thoughts about it at https://github.com/crate/crate-python/pull/442#pullrequestreview-1110538218 ff., and finally settled with this implementation, separately from the baseline implementation for the data type converter.

### Details
This patch adds additional convenience based on the data type converter machinery added with #442.

- A `time_zone` _keyword argument_ can be passed to both the `connect()` method, or when creating new `Cursor` objects.
- The `time_zone` _attribute_ can also be changed at runtime on both the `connection` and `cursor` object instances.

Different ways to populate the `time_zone` value are supported. Some examples::

- ``datetime.timezone.utc``
- ``datetime.timezone(datetime.timedelta(hours=7), name="MST")``
- ``pytz.timezone("Australia/Sydney")``
- ``zoneinfo.ZoneInfo("Australia/Sydney")``
- ``+0530`` (UTC offset in string format)

### Acknowledgements
This interface was inspired by the DBAPI drivers for MySQL and Elasticsearch. Thanks.

- https://dev.mysql.com/doc/connector-python/en/connector-python-api-mysqlconnection-time-zone.html
- https://github.com/preset-io/elasticsearch-dbapi#time-zone

### Synopsis
Use `time_zone` argument when creating a new connection. Here, use a `pytz.timezone` object.
```python
>>> import pytz
>>> from crate.client import connect

>>> connect("localhost:4200", time_zone=pytz.timezone("Australia/Sydney"))
>>> cursor = connection.cursor()
>>> cursor.execute(stmt)
>>> cursor.fetchone()
['foo', datetime.datetime(2022, 7, 19, 4, 10, 36, 758000, tzinfo=<DstTzInfo 'Australia/Sydney' AEST+10:00:00 STD>)]
```

Use `time_zone` argument when creating a new cursor. Here, use an UTC offset string.
```python
>>> from crate.client import connect

>>> connection = connect("localhost:4200")
>>> cursor = connection.cursor(time_zone="+0530")
>>> cursor.execute(stmt)
>>> cursor.fetchone()
['foo', datetime.datetime(2022, 7, 18, 23, 40, 36, 758000, tzinfo=datetime.timezone(datetime.timedelta(seconds=19800), '+0530'))]
```

### References
- #395
- #426 
- #437 
- #442


### Backlog
- For bringing this functionality to the SQLAlchemy dialect, https://github.com/spoqa/sqlalchemy-utc may be of interest.
