### PR TITLE
CI: Disable failing on code coverage report upload, Codecov has issues

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
     env:
       CRATEDB_VERSION: ${{ matrix.cratedb-version }}
       SQLALCHEMY_VERSION: ${{ matrix.sqla-version }}
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
### Problem

Code coverage report upload to Codecov started failing intermittently. Example: https://github.com/crate/crate-python/actions/runs/3177244114/jobs/5177463683

```
[2022-10-03T20:30:53.977Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/)
Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
Error: Codecov: Failed to properly upload: The process '/Users/runner/work/_actions/codecov/codecov-action/v3/dist/codecov' failed with exit code 255
```

<details>

```
Run codecov/codecov-action@v3
==> macos OS detected
https://uploader.codecov.io/latest/macos/codecov.SHA256SUM
==> SHASUM file signed by key id 806bb28aed779869
==> Uploader SHASUM verified (ccc032e70958ea3eca9bd15c7fdad5bbacc279c3bab22f227417573356569666  codecov)
==> Running version latest
==> Running version v0.3.2
/Users/runner/work/_actions/codecov/codecov-action/v3/dist/codecov -n  -Q github-action-3.1.1 -Z -C 6492325de0ce91500fa435a9f7e6afb27a579b2b
[2022-10-03T20:30:52.747Z] ['info'] 
     _____          _
    / ____|        | |
   | |     ___   __| | ___  ___ _____   __
   | |    / _ \ / _` |/ _ \/ __/ _ \ \ / /
   | |___| (_) | (_| |  __/ (_| (_) \ V /
    \_____\___/ \__,_|\___|\___\___/ \_/

  Codecov report uploader 0.3.2
[2022-10-03T20:30:52.772Z] ['info'] => Project root located at: /Users/runner/work/crate-python/crate-python
[2022-10-03T20:30:52.778Z] ['info'] -> No token specified or token is empty
[2022-10-03T20:30:52.830Z] ['info'] Searching for coverage files...
[2022-10-03T20:30:53.501Z] ['info'] Warning: Some files located via search were excluded from upload.
[2022-10-03T20:30:53.501Z] ['info'] If Codecov did not locate your files, please review https://docs.codecov.com/docs/supported-report-formats
[2022-10-03T20:30:53.502Z] ['info'] => Found 2 possible coverage files:
  coverage.xml
  .venv/bin/coverage-3.11
[2022-10-03T20:30:53.502Z] ['info'] Processing /Users/runner/work/crate-python/crate-python/coverage.xml...
[2022-10-03T20:30:53.540Z] ['info'] Processing /Users/runner/work/crate-python/crate-python/.venv/bin/coverage-3.11...
[2022-10-03T20:30:53.572Z] ['info'] Detected GitHub Actions as the CI provider.
[2022-10-03T20:30:53.574Z] ['info'] Pinging Codecov: https://codecov.io/upload/v4?package=github-action-3.1.1-uploader-0.3.2&token=*******&branch=amo%2Fpython311&build=3177244114&build_url=https%3A%2F%2Fgithub.com%2Fcrate%2Fcrate-python%2Factions%2Fruns%2F3177244114&commit=6492325de0ce91500fa435a9f7e6afb27a579b2b&job=Tests&pr=450&service=github-actions&slug=crate%2Fcrate-python&name=&tag=&flags=&parent=
[2022-10-03T20:30:53.977Z] ['error'] There was an error running the uploader: Error uploading to [https://codecov.io:](https://codecov.io/) Error: There was an error fetching the storage URL during POST: 404 - {'detail': ErrorDetail(string='Unable to locate build via Github Actions API. Please upload with the Codecov repository upload token to resolve issue.', code='not_found')}
Error: Codecov: Failed to properly upload: The process '/Users/runner/work/_actions/codecov/codecov-action/v3/dist/codecov' failed with exit code 255
```
</details>


### References
Others are observing the same issue. Apparently, https://codecov.io occasionally responds with `404 Not Found`.

- https://github.com/codecov/codecov-action/issues/557
- https://github.com/codecov/codecov-action/issues/595
- https://github.com/codecov/codecov-action/issues/598
- https://github.com/codecov/codecov-action/issues/837
- https://community.codecov.com/t/intermittent-unable-to-locate-build-via-github-actions-api/2936
- https://community.codecov.com/t/unable-to-locate-build-via-github-actions-api-for-the-public-repository/3894


### Debugging
Trying different approaches like 67d63cc3f or da277721dd.


### Supposed solution
The patch da277721dd explicitly adds the use of the `with.token` option, as confirmed by others to improve the behaviour even on public repos.

The token is not required for public repos, but it makes the workflow less likely to randomly fail because of a limit in codecov CI capabilities [1]. However, the secret token does not _always_ save from erratic behaviour [2-4].

[1] https://github.com/codecov/codecov-action/issues/557#issuecomment-1216749652
[2] https://github.com/codecov/codecov-action/issues/557#issuecomment-1223737955
[3] https://github.com/codecov/codecov-action/issues/598#issuecomment-1223307820
[4] https://github.com/orgs/community/discussions/25701


### Still croaks
Example: https://github.com/crate/crate-python/actions/runs/3177539843/jobs/5178341299

### Solution
Using cb2d904b8 instead now, using `fail_ci_if_error: false`. C'est la vie. 🌧️ 