### PR TITLE
CI: `setup_ci` should run before `bootstrap.sh`

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -36,11 +36,11 @@ jobs:
       - name: Invoke tests
         run: |
 
-          # Bootstrap environment.
-          source bootstrap.sh
-
           # Propagate build matrix information.
           ./devtools/setup_ci.sh
+
+          # Bootstrap environment.
+          source bootstrap.sh
 
           # Invoke validation tasks.
           flake8 src bin

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,11 @@ jobs:
       - name: Invoke tests
         run: |
 
-          # Bootstrap environment.
-          source bootstrap.sh
-
           # Propagate build matrix information.
           ./devtools/setup_ci.sh
+
+          # Bootstrap environment.
+          source bootstrap.sh
 
           # Invoke validation tasks.
           flake8 src bin


### PR DESCRIPTION
On the "nightly" runs, the test suite did not actually use CrateDB nightly builds, but used the version defined in `versions.cfg` instead.

Because of that, it is currently using CrateDB 5.0.1, even on the nightly runs, see https://github.com/crate/crate-python/actions/runs/3194158943/jobs/5213450280#step:4:170.
