### PR TITLE
Dependencies: Limit `geojson` package to version <3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     },
     extras_require=dict(
         sqlalchemy=['sqlalchemy>=1.0,<1.5',
-                    'geojson>=2.5.0'],
+                    'geojson>=2.5.0,<3'],
         test=['tox>=3,<4',
               'zope.testing>=4,<5',
               'zope.testrunner>=5,<6',


### PR DESCRIPTION
Given that the package did not receive any update since 2019, chances are that the next release may bump to a major version, which might not be compatible.