### PR TITLE
Improve SQLAlchemy's `CrateDialect.get_pk_constraint` for CrateDB>=5.1

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-11', 'macos-12']
+        os: ['ubuntu-20.04', 'ubuntu-22.04']  # 'macos-11', 'macos-12'
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
         cratedb-version: ['nightly']
         sqla-version: ['latest']

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,8 @@ Changes for crate
 Unreleased
 ==========
 
+- Improved SQLAlchemy's ``CrateDialect.get_pk_constraint`` to be compatible
+  with breaking changes in CrateDB >=5.1.0.
 
 2022/07/04 0.27.1
 =================


### PR DESCRIPTION
Hi there,

https://github.com/crate/crate/pull/12652, to be released with CrateDB 5.1, introduced an adjustment which needs compensation on the driver level when reflecting the database schema, like https://github.com/crate/pgjdbc/pull/40. It has also been reported as a regression at https://github.com/crate/crate/issues/13102.

Since CrateDB 3.0.0 already, it would have been correct to use the `information_schema.key_column_usage.table_schema` column instead of `table_catalog` (mostly contains value `doc`, the default schema of CrateDB). Now, with CrateDB >=5.1, `table_catalog` will always return `crate`, thus the need for a fix.

With this adjustment, running the test suite against _CrateDB nightly_ succeeds again [^1], where it failed previously on this matter [^2].

With kind regards,
Andreas.

[^1]: https://github.com/crate/crate-python/actions/runs/3198965176
[^2]: https://github.com/crate/crate-python/actions/runs/3198411459/jobs/5222896383#step:4:347
