### PR TITLE
GHA: Cancel in-progress jobs if pushing to PR

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -9,6 +9,10 @@ on:
   schedule:
     - cron: '0 7 * * *'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   documentation:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
     branches: [ master ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
See https://docs.github.com/en/actions/using-jobs/using-concurrency. Should reduce the resource usage a bit and may speed up things.

Copy of https://github.com/crate/crate/commit/95863241. Thank you, @mfussenegger!
