### PR TITLE
CI: Add support for Python 3.11

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-20.04', 'ubuntu-22.04', 'macos-11', 'macos-12']
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
         cratedb-version: ['nightly']
         sqla-version: ['latest']
       fail-fast: false

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ['3.7', '3.8', '3.9', '3.10']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11-dev']
         cratedb-version: ['5.0.1']
         sqla-version: ['1.3.24', '1.4.41']
       fail-fast: true

--- a/setup.py
+++ b/setup.py
@@ -90,6 +90,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Database'


### PR DESCRIPTION
Python 3.11 will be released in about a month, on 2022-10-24.

I accidentally merged #450 into another branch, but it somehow disappeared at all, which is weird. This is another attempt to get it straight to `master`.
