### PR TITLE
TIMESTAMP->dt: Use ImportError instead of ModuleNotFoundError

### DIFF
--- a/docs/query.rst
+++ b/docs/query.rst
@@ -293,7 +293,7 @@ Let's exercise all of them.
 
     >>> try:
     ...     import zoneinfo
-    ... except ModuleNotFoundError:
+    ... except ImportError:
     ...     from backports import zoneinfo
 
     >>> cursor.time_zone = zoneinfo.ZoneInfo("Australia/Sydney")

--- a/src/crate/client/doctests/cursor.txt
+++ b/src/crate/client/doctests/cursor.txt
@@ -417,7 +417,7 @@ Let's exercise all of them::
 
     >>> try:
     ...     import zoneinfo
-    ... except ModuleNotFoundError:
+    ... except ImportError:
     ...     from backports import zoneinfo
     >>> cursor.time_zone = zoneinfo.ZoneInfo("Australia/Sydney")
     >>> cursor.execute('')

--- a/src/crate/client/test_cursor.py
+++ b/src/crate/client/test_cursor.py
@@ -25,7 +25,7 @@ from unittest import TestCase
 from unittest.mock import MagicMock
 try:
     import zoneinfo
-except ModuleNotFoundError:
+except ImportError:
     from backports import zoneinfo
 
 import pytz


### PR DESCRIPTION
Just a variant of #445 in order to re-evaluate https://github.com/pganssle/zoneinfo/issues/122.