### PR TITLE
CI: Do not fail CI step when uploading coverage report fails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -58,4 +58,4 @@ jobs:
       - name: Upload coverage results to Codecov
         uses: codecov/codecov-action@v3
         with:
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
Codecov has issues again.

```
Error: There was an error fetching the storage URL during POST:
503 - upstream connect error or disconnect/reset before headers.
reset reason: connection failure
```

-- https://github.com/crate/crate-python/actions/runs/3516230397/jobs/5892516734#step:5:44