### PR TITLE
Tests: Use more specific assertXXX methods, as suggested by CodeQL

### DIFF
--- a/src/crate/client/sqlalchemy/tests/bulk_test.py
+++ b/src/crate/client/sqlalchemy/tests/bulk_test.py
@@ -65,7 +65,7 @@ class SqlAlchemyBulkTest(TestCase):
             {'rowcount': 1},
         ]
         self.session.bulk_save_objects(chars)
-        (stmt, bulk_args), _kwargs = fake_cursor.executemany.call_args
+        (stmt, bulk_args), _ = fake_cursor.executemany.call_args
 
         expected_stmt = "INSERT INTO characters (name, age) VALUES (?, ?)"
         self.assertEqual(expected_stmt, stmt)

--- a/src/crate/client/sqlalchemy/tests/compiler_test.py
+++ b/src/crate/client/sqlalchemy/tests/compiler_test.py
@@ -48,14 +48,14 @@ class SqlAlchemyCompilerTest(TestCase):
             self.sqlite_engine, self.update, self.values, {}
         )
 
-        assert hasattr(clauseelement, '_crate_specific') is False
+        self.assertFalse(hasattr(clauseelement, '_crate_specific'))
 
     def test_crate_update_rewritten(self):
         clauseelement, multiparams, params = crate_before_execute(
             self.crate_engine, self.update, self.values, {}
         )
 
-        assert hasattr(clauseelement, '_crate_specific') is True
+        self.assertTrue(hasattr(clauseelement, '_crate_specific'))
 
     def test_bulk_update_on_builtin_type(self):
         """
@@ -68,4 +68,4 @@ class SqlAlchemyCompilerTest(TestCase):
             self.crate_engine, self.update, data, None
         )
 
-        assert hasattr(clauseelement, '_crate_specific') is False
+        self.assertFalse(hasattr(clauseelement, '_crate_specific'))

--- a/src/crate/client/sqlalchemy/tests/connection_test.py
+++ b/src/crate/client/sqlalchemy/tests/connection_test.py
@@ -53,7 +53,7 @@ class SqlAlchemyConnectionTest(TestCase):
     def test_connection_server_uri_invalid_port(self):
         with self.assertRaises(ValueError) as context:
             sa.create_engine("crate://foo:bar")
-        self.assertTrue("invalid literal for int() with base 10: 'bar'" in str(context.exception))
+        self.assertIn("invalid literal for int() with base 10: 'bar'", str(context.exception))
 
     def test_connection_server_uri_https_with_trusted_user(self):
         engine = sa.create_engine(

--- a/src/crate/client/sqlalchemy/tests/dict_test.py
+++ b/src/crate/client/sqlalchemy/tests/dict_test.py
@@ -129,11 +129,11 @@ class SqlAlchemyDictTypeTest(TestCase):
     def test_assign_null_to_object_array(self):
         session, Character = self.set_up_character_and_cursor()
         char_1 = Character(name='Trillian', data_list=None)
-        self.assertTrue(char_1.data_list is None)
+        self.assertIsNone(char_1.data_list)
         char_2 = Character(name='Trillian', data_list=1)
-        self.assertTrue(char_2.data_list == [1])
+        self.assertEqual(char_2.data_list, [1])
         char_3 = Character(name='Trillian', data_list=[None])
-        self.assertTrue(char_3.data_list == [None])
+        self.assertEqual(char_3.data_list, [None])
 
     @patch('crate.client.connection.Cursor', FakeCursor)
     def test_assign_to_craty_type_after_commit(self):
@@ -144,7 +144,7 @@ class SqlAlchemyDictTypeTest(TestCase):
         session.add(char)
         session.commit()
         char.data = {'x': 1}
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
             "UPDATE characters SET data = ? WHERE characters.name = ?",
@@ -165,13 +165,13 @@ class SqlAlchemyDictTypeTest(TestCase):
             print(fake_cursor.mock_calls)
             raise
 
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
         try:
             session.commit()
         except Exception:
             print(fake_cursor.mock_calls)
             raise
-        self.assertFalse(char in session.dirty)
+        self.assertNotIn(char, session.dirty)
 
     @patch('crate.client.connection.Cursor', FakeCursor)
     def test_partial_dict_update(self):
@@ -248,7 +248,7 @@ class SqlAlchemyDictTypeTest(TestCase):
         session.add(char)
         session.commit()
         del char.data['x']
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
             ("UPDATE characters SET data['x'] = ? "
@@ -273,7 +273,7 @@ class SqlAlchemyDictTypeTest(TestCase):
         session.commit()
         del char.data['x']
         char.data['x'] = 4
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
             ("UPDATE characters SET data['x'] = ? "
@@ -297,7 +297,7 @@ class SqlAlchemyDictTypeTest(TestCase):
         session.commit()
         char.data['x'] = 4
         del char.data['x']
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
             ("UPDATE characters SET data['x'] = ? "
@@ -322,7 +322,7 @@ class SqlAlchemyDictTypeTest(TestCase):
         char.data['x'] = 4
         del char.data['x']
         char.data['x'] = 3
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
             ("UPDATE characters SET data['x'] = ? "
@@ -362,7 +362,7 @@ class SqlAlchemyDictTypeTest(TestCase):
     def test_object_array_setitem_change_tracking(self):
         session, char = self._setup_object_array_char()
         char.data_list[1] = {'3': 3}
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
             ("UPDATE characters SET data_list = ? "
@@ -384,7 +384,7 @@ class SqlAlchemyDictTypeTest(TestCase):
     def test_nested_object_change_tracking(self):
         session, char = self._setup_nested_object_char()
         char.data["nested"]["x"] = 3
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
             ("UPDATE characters SET data['nested'] = ? "
@@ -397,7 +397,7 @@ class SqlAlchemyDictTypeTest(TestCase):
         session, char = self._setup_nested_object_char()
         # change deep nested object
         char.data["nested"]["y"]["z"] = 5
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
             ("UPDATE characters SET data['nested'] = ? "
@@ -410,7 +410,7 @@ class SqlAlchemyDictTypeTest(TestCase):
         session, char = self._setup_nested_object_char()
         # delete nested object
         del char.data["nested"]["y"]["z"]
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
         session.commit()
         fake_cursor.execute.assert_called_with(
             ("UPDATE characters SET data['nested'] = ? "
@@ -422,35 +422,35 @@ class SqlAlchemyDictTypeTest(TestCase):
     def test_object_array_append_change_tracking(self):
         session, char = self._setup_object_array_char()
         char.data_list.append({'3': 3})
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
 
     @patch('crate.client.connection.Cursor', FakeCursor)
     def test_object_array_insert_change_tracking(self):
         session, char = self._setup_object_array_char()
         char.data_list.insert(0, {'3': 3})
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
 
     @patch('crate.client.connection.Cursor', FakeCursor)
     def test_object_array_slice_change_tracking(self):
         session, char = self._setup_object_array_char()
         char.data_list[:] = [{'3': 3}]
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
 
     @patch('crate.client.connection.Cursor', FakeCursor)
     def test_object_array_extend_change_tracking(self):
         session, char = self._setup_object_array_char()
         char.data_list.extend([{'3': 3}])
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
 
     @patch('crate.client.connection.Cursor', FakeCursor)
     def test_object_array_pop_change_tracking(self):
         session, char = self._setup_object_array_char()
         char.data_list.pop()
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)
 
     @patch('crate.client.connection.Cursor', FakeCursor)
     def test_object_array_remove_change_tracking(self):
         session, char = self._setup_object_array_char()
         item = char.data_list[0]
         char.data_list.remove(item)
-        self.assertTrue(char in session.dirty)
+        self.assertIn(char, session.dirty)

--- a/src/crate/client/sqlalchemy/tests/update_test.py
+++ b/src/crate/client/sqlalchemy/tests/update_test.py
@@ -79,8 +79,8 @@ class SqlAlchemyUpdateTest(TestCase):
         self.assertEqual(expected_stmt, stmt)
         self.assertEqual(40, args[0])
         dt = datetime.strptime(args[1], '%Y-%m-%dT%H:%M:%S.%fZ')
-        self.assertTrue(isinstance(dt, datetime))
-        self.assertTrue(dt > now)
+        self.assertIsInstance(dt, datetime)
+        self.assertGreater(dt, now)
         self.assertEqual('Arthur', args[2])
 
     @patch('crate.client.connection.Cursor', FakeCursor)
@@ -108,5 +108,5 @@ class SqlAlchemyUpdateTest(TestCase):
         self.assertEqual('Julia', args[0])
         self.assertEqual({'favorite_book': 'Romeo & Juliet'}, args[1])
         dt = datetime.strptime(args[2], '%Y-%m-%dT%H:%M:%S.%fZ')
-        self.assertTrue(isinstance(dt, datetime))
-        self.assertTrue(dt > before_update_time)
+        self.assertIsInstance(dt, datetime)
+        self.assertGreater(dt, before_update_time)

--- a/src/crate/client/test_cursor.py
+++ b/src/crate/client/test_cursor.py
@@ -107,7 +107,7 @@ class CursorTest(TestCase):
         c.execute("")
         with self.assertRaises(ValueError) as ex:
             c.fetchone()
-        assert ex.exception.args == ("999 is not a valid DataType",)
+        self.assertEqual(ex.exception.args, ("999 is not a valid DataType",))
 
     def test_execute_array_with_converter(self):
         client = ClientMocked()
@@ -150,7 +150,7 @@ class CursorTest(TestCase):
 
         with self.assertRaises(ValueError) as ex:
             cursor.fetchone()
-        assert ex.exception.args == ("Data type 6 is not implemented as collection type",)
+        self.assertEqual(ex.exception.args, ("Data type 6 is not implemented as collection type",))
 
     def test_execute_nested_array_with_converter(self):
         client = ClientMocked()

--- a/src/crate/client/test_http.py
+++ b/src/crate/client/test_http.py
@@ -282,8 +282,8 @@ class HttpClientTest(TestCase):
         server = 'http://localhost:4200'
         client = Client(servers=server)
         conn_kw = client.server_pool[server].pool.conn_kw
-        self.assertTrue(
-            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1) in conn_kw['socket_options']
+        self.assertIn(
+            (socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1), conn_kw['socket_options']
         )
         client.close()
 
@@ -454,13 +454,13 @@ class RequestsCaBundleTest(TestCase):
 
     def test_remove_certs_for_non_https(self):
         d = _remove_certs_for_non_https('https', {"ca_certs": 1})
-        self.assertTrue('ca_certs' in d)
+        self.assertIn('ca_certs', d)
 
         kwargs = {'ca_certs': 1, 'foobar': 2, 'cert_file': 3}
         d = _remove_certs_for_non_https('http', kwargs)
-        self.assertTrue('ca_certs' not in d)
-        self.assertTrue('cert_file' not in d)
-        self.assertTrue('foobar' in d)
+        self.assertNotIn('ca_certs', d)
+        self.assertNotIn('cert_file', d)
+        self.assertIn('foobar', d)
 
 
 class TimeoutRequestHandler(BaseHTTPRequestHandler):
@@ -572,8 +572,8 @@ class RetryOnTimeoutServerTest(TestingHttpServerTestCase):
         try:
             self.client.sql("select * from fake")
         except ConnectionError as e:
-            self.assertTrue('Read timed out' in e.message,
-                            msg='Error message must contain: Read timed out')
+            self.assertIn('Read timed out', e.message,
+                          msg='Error message must contain: Read timed out')
         self.assertEqual(TestingHTTPServer.SHARED['count'], 1)
 
 


### PR DESCRIPTION
### About
From the outcome of running a CodeQL scan on behalf of #467, this patch addresses some of the items currently/previously listed at [^1]. Effectively, it will resolve all of the _Imprecise assert_ check notices issued by CodeQL.

### Example
![image](https://user-images.githubusercontent.com/453543/203150897-8b6ef438-fef2-4eaa-94e4-93ad011e4dc4.png)

[^1]: https://github.com/crate/crate-python/pull/467/checks?check_run_id=9621584111