### PR TITLE
Fix generating appropriate syntax for OFFSET/LIMIT clauses

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,10 @@ Unreleased
 - Added a generic data type converter to the ``Cursor`` object, for converting
   fetched data from CrateDB data types to Python data types.
 
+- Fixed generating appropriate syntax for OFFSET/LIMIT clauses. It was possible
+  that SQL statement clauses like ``LIMIT -1`` could have been generated. Both
+  PostgreSQL and CrateDB only accept ``LIMIT ALL`` instead.
+
 
 2022/10/10 0.27.2
 =================

--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -23,6 +23,7 @@ import string
 from collections import defaultdict
 
 import sqlalchemy as sa  # lgtm[py/import-and-import-from]
+from sqlalchemy.dialects.postgresql.base import PGCompiler
 from sqlalchemy.sql import compiler, crud, selectable  # lgtm[py/import-and-import-from]
 from .types import MutableDict
 from .sa_version import SA_VERSION, SA_1_4
@@ -288,6 +289,12 @@ class CrateCompiler(compiler.SQLCompiler):
                 update_stmt, self.returning)
 
         return text
+
+    def limit_clause(self, select, **kw):
+        """
+        Generate OFFSET / LIMIT clause, PostgreSQL-compatible.
+        """
+        return PGCompiler.limit_clause(self, select, **kw)
 
     def _get_crud_params(compiler, stmt, **kw):
         """ extract values from crud parameters


### PR DESCRIPTION
Hi.

This patch intends to fix #453.

The standard SQLAlchemy statement compiler may generate `LIMIT -1` clauses, but PostgreSQL and CrateDB do not accept them, and need `LIMIT ALL` instead.

The easy solution is to make `CrateCompiler` re-use the existing `PGCompiler.limit_clause`.

With kind regards,
Andreas.
