### PR TITLE
Dependencies: Limit to `urllib3>=1.9,<2`, because urllib3-2.x is coming

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,11 +24,6 @@ import os
 import re
 
 
-requirements = [
-    'urllib3>=1.9',
-]
-
-
 def read(path):
     with open(os.path.join(os.path.dirname(__file__), path)) as f:
         return f.read()
@@ -63,6 +58,7 @@ setup(
             'crate = crate.client.sqlalchemy:CrateDialect'
         ]
     },
+    install_requires=['urllib3>=1.9,<2'],
     extras_require=dict(
         sqlalchemy=['sqlalchemy>=1.0,<1.5',
                     'geojson>=2.5.0,<3'],
@@ -77,7 +73,6 @@ setup(
              'crate-docs-theme'],
     ),
     python_requires='>=3.4',
-    install_requires=requirements,
     package_data={'': ['*.txt']},
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This patch is in the same spirit like #458.

Because urllib3 version 2.0 will be published soon [^1], it will be more safe to limit to urllib3 1.x, and to explicitly unlock it when we are sure the code base is compatible. #480 will exercise the update to the most recent alpha release of urllib3 2.x.

[^1]: See also https://pypi.org/project/urllib3/#history.
