### PR TITLE
SQLAlchemy deprecation in `SqlAlchemyDictTypeTest`

### DIFF
--- a/src/crate/client/sqlalchemy/tests/dict_test.py
+++ b/src/crate/client/sqlalchemy/tests/dict_test.py
@@ -43,8 +43,7 @@ class SqlAlchemyDictTypeTest(TestCase):
         self.mytable = sa.Table('mytable',
                                 metadata,
                                 sa.Column('name', sa.String),
-                                sa.Column('data', Craty),
-                                autoload_with=self.engine)
+                                sa.Column('data', Craty))
 
     def assertSQL(self, expected_str, actual_expr):
         self.assertEqual(expected_str, str(actual_expr).replace('\n', ''))


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
@amotl, this is an attempt at fixing the deprecation warning in `SqlAlchemyDictTypeTest`. I'm not 100% sure about the `test_update_with_dict_column`, this would need manual verification.

## Checklist

 - [X] [CLA](https://crate.io/community/contribute/cla/) is signed
