### PR TITLE
SA20: Fix SqlAlchemy tests to use "qmark" paramstyle again

### DIFF
--- a/src/crate/client/sqlalchemy/tests/dict_test.py
+++ b/src/crate/client/sqlalchemy/tests/dict_test.py
@@ -40,13 +40,13 @@ class SqlAlchemyDictTypeTest(TestCase):
 
     def setUp(self):
         self.engine = sa.create_engine('crate://')
-        # FIXME: Deprecated with SA20.
-        metadata = sa.MetaData(bind=self.engine)
+        metadata = sa.MetaData()
         self.mytable = sa.Table('mytable', metadata,
                                 sa.Column('name', sa.String),
                                 sa.Column('data', Craty))
 
-    def assertSQL(self, expected_str, actual_expr):
+    def assertSQL(self, expected_str, selectable):
+        actual_expr = selectable.compile(bind=self.engine)
         self.assertEqual(expected_str, str(actual_expr).replace('\n', ''))
 
     def test_select_with_dict_column(self):

--- a/src/crate/client/sqlalchemy/tests/insert_from_select_test.py
+++ b/src/crate/client/sqlalchemy/tests/insert_from_select_test.py
@@ -75,8 +75,7 @@ class SqlAlchemyInsertFromSelectTest(TestCase):
         ins = insert(self.character_archived).from_select(['name', 'age'], sel)
         self.session.execute(ins)
         self.session.commit()
-        # TODO: Verify if this is correct.
         self.assertSQL(
-            "INSERT INTO characters_archive (name, age) SELECT characters.name, characters.age FROM characters WHERE characters.status = :status_1",
-            ins
+            "INSERT INTO characters_archive (name, age) SELECT characters.name, characters.age FROM characters WHERE characters.status = ?",
+            ins.compile(bind=self.engine)
         )


### PR DESCRIPTION
Dear @hammerhead,

regarding your recent patch GH-486 about the fix to `SqlAlchemyDictTypeTest`, I learned more about the details while working on GH-488. Based on the rationale provided below, I think 30d6ea46 is the right fix at this place, **to retain the "qmark" paramstyle** being sent to the driver. It makes sense to look at this very commit only, in order to not get distracted by the other changes induced by reverting your original commit b20fabad0.

Within GH-490, I made the same mistake on overlooking this detail at the `SqlAlchemyInsertFromSelectTest`, and errorneously followed the updated output from the reported diff, effectively accepting a change to the **"named" paramstyle**. efca25e5f gets it right again, by also binding the insert clause to an engine.

With kind regards,
Andreas.

### Rationale
"Implicit" and "Connectionless" execution, and "bound metadata", have been removed beginning with SQLAlchemy 2.0 [^1].

Earlier and contemporary versions of SQLAlchemy had the ability to associate an `Engine` with a `MetaData` object. This allowed a number of so-called "connectionless" execution patterns. That is no longer possible.

Instead, the association with an `Engine` object has to be conducted differently. On this very spot, in the context of the `dict_test` test cases, the most easy fix was to move it to the invocation of the `compile()` method of the `selectable` instance, which is now returned by the `sqlalchemy.sql.*` primitives:
```python
expression = selectable.compile(bind=self.engine)
```
This is needed, because otherwise, when not associating `Engine` with `MetaData` properly, `CrateDialect` would be bypassed, and the "paramstyle" [^2] of SQLAlchemy's `DefaultDialect` would be used, which is actually the **"named" paramstyle** [^3], as originally reflected per b20fabad0.

This is probably wrong, because the CrateDB Python driver uses the **"qmark" paramstyle** [^4].

[^1]: https://docs.sqlalchemy.org/en/20/changelog/migration_20.html#implicit-and-connectionless-execution-bound-metadata-removed
[^2]: https://docs.sqlalchemy.org/en/20/core/engines.html#sqlalchemy.create_engine.params.paramstyle
[^3]: https://github.com/sqlalchemy/sqlalchemy/blob/rel_2_0_0b4/lib/sqlalchemy/engine/default.py#L204
[^4]: https://github.com/crate/crate-python/blob/0.29.0/src/crate/client/__init__.py#L36
