### PR TITLE
CI: Fix installation of defined SQLAlchemy version, bringing back SA13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,9 @@ jobs:
           # Bootstrap environment.
           source bootstrap.sh
 
+          # Report about the test matrix slot.
+          echo "Invoking tests with CrateDB ${CRATEDB_VERSION} and SQLAlchemy ${SQLALCHEMY_VERSION}"
+
           # Invoke validation tasks.
           flake8 src bin
           coverage run bin/test -vv1

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -65,6 +65,15 @@ function setup_package() {
     # Install package in editable mode.
     pip install --editable='.[sqlalchemy,test,doc]'
 
+    # Install designated SQLAlchemy version.
+    if [ -n "${SQLALCHEMY_VERSION}" ]; then
+      if [ "${SQLALCHEMY_VERSION}" = "latest" ]; then
+        pip install "sqlalchemy" --upgrade
+      else
+        pip install "sqlalchemy==${SQLALCHEMY_VERSION}"
+      fi
+    fi
+
 }
 
 function run_buildout() {

--- a/devtools/setup_ci.sh
+++ b/devtools/setup_ci.sh
@@ -10,20 +10,6 @@ function main() {
     echo "Environment variable 'CRATEDB_VERSION' needed"
     exit 1
   }
-  [ -z ${SQLALCHEMY_VERSION} ] && {
-    echo "Environment variable 'SQLALCHEMY_VERSION' needed"
-    exit 1
-  }
-
-  # Let's go.
-  echo "Invoking tests with CrateDB ${CRATEDB_VERSION} and SQLAlchemy ${SQLALCHEMY_VERSION}"
-
-  # Install designated SQLAlchemy version.
-  if [ ${SQLALCHEMY_VERSION} = "latest" ]; then
-    pip install "sqlalchemy" --upgrade
-  else
-    pip install "sqlalchemy==${SQLALCHEMY_VERSION}"
-  fi
 
   # Replace CrateDB version.
   if [ ${CRATEDB_VERSION} = "nightly" ]; then

--- a/src/crate/client/sqlalchemy/tests/compiler_test.py
+++ b/src/crate/client/sqlalchemy/tests/compiler_test.py
@@ -26,6 +26,7 @@ from crate.client.sqlalchemy.compiler import crate_before_execute
 import sqlalchemy as sa
 from sqlalchemy.sql import update, text
 
+from crate.client.sqlalchemy.sa_version import SA_VERSION, SA_1_4
 from crate.client.sqlalchemy.types import Craty
 
 
@@ -77,7 +78,10 @@ class SqlAlchemyCompilerTest(TestCase):
         self.metadata.bind = self.crate_engine
         selectable = self.mytable.select().offset(5)
         statement = str(selectable.compile())
-        self.assertEqual(statement, "SELECT mytable.name, mytable.data \nFROM mytable\n LIMIT ALL OFFSET ?")
+        if SA_VERSION >= SA_1_4:
+            self.assertEqual(statement, "SELECT mytable.name, mytable.data \nFROM mytable\n LIMIT ALL OFFSET ?")
+        else:
+            self.assertEqual(statement, "SELECT mytable.name, mytable.data \nFROM mytable \n LIMIT ALL OFFSET ?")
 
     def test_select_with_limit(self):
         """


### PR DESCRIPTION
### Problem
A flaw with the SQLAlchemy installer for CI has been discovered when running tests on GH-485. It says »Using SQLAlchemy version: 1.4.45« here [^1], while the test matrix slot says it should actually be SA13.

### Reason
The order of operations was wrong. So, previously, the process would always install SQLAlchemy 1.4, effectively skipping testing on SQLAlchemy 1.3.

### Trivia
Indeed, another fix was needed to compensate for bringing back SA13: 4532ef79fb started using the `PGCompiler` for rendering`LIMIT` clauses, which apparently received a fix with SA14. So, 36a99cad was needed to make one of our test cases compatible with SA13 again.

[^1]: https://github.com/crate/crate-python/actions/runs/3754133520/jobs/6378077603#step:4:222