### PR TITLE
CI: Fix `502 Server Error: Bad Gateway` errors for error path test case

### DIFF
--- a/docs/by-example/http.rst
+++ b/docs/by-example/http.rst
@@ -211,11 +211,11 @@ an exception is raised when the timeout is reached::
 
 When connecting to non-CrateDB servers, the HttpClient will raise a ConnectionError like this::
 
-    >>> http_client = HttpClient(["https://httpbin.org/html"])
+    >>> http_client = HttpClient(["https://example.org/"])
     >>> http_client.server_infos(http_client._get_server())
     Traceback (most recent call last):
     ...
-    crate.client.exceptions.ProgrammingError: Invalid server response of content-type 'text/html; charset=utf-8':
+    crate.client.exceptions.ProgrammingError: Invalid server response of content-type 'text/html; charset=UTF-8':
     ...
     >>> http_client.close()
 


### PR DESCRIPTION
For evaluating an error path of the code base, when connecting to non-CrateDB servers, a connection to httpbin.org was made. Apparently, they brought rate limiting in place, so the job would occasionally fail when running on a larger test matrix.

This attempts to resolve GH-493.