### PR TITLE
CI: To save resources, only use the most recent Python version on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,10 +19,20 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: ['ubuntu-latest', 'macos-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         cratedb-version: ['5.1.1']
         sqla-version: ['1.3.24', '1.4.44']
+        # To save resources, only use the most recent Python version on macOS.
+        exclude:
+          - os: 'macos-latest'
+            python-version: '3.7'
+          - os: 'macos-latest'
+            python-version: '3.8'
+          - os: 'macos-latest'
+            python-version: '3.9'
+          - os: 'macos-latest'
+            python-version: '3.10'
       fail-fast: true
     env:
       CRATEDB_VERSION: ${{ matrix.cratedb-version }}


### PR DESCRIPTION
The whole test suite weighs in with a total of one hour(!) across all test matrix slots [^1]. I think we can tame that a bit, by running only the most recent version of Python on the matrix slot for macOS. It will also speed up the total runtime.

- **Before:** Run time: 7-11 minutes, Sum: 60 minutes [^1]
- **After:** Run time: 6 minutes, Sum: 33 minutes [^2]

[^1]: https://github.com/crate/crate-python/actions/runs/3758815214/usage
[^2]: https://github.com/crate/crate-python/actions/runs/3759209356/usage