### PR TITLE
CI: Run CodeQL scan on multiple SQLAlchemy versions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,8 +17,9 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+
   analyze:
-    name: Analyze
+    name: "Analyze with SQLAlchemy ${{ matrix.sqla-version }}"
     runs-on: ubuntu-latest
     permissions:
       actions: read
@@ -29,6 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         language: [ python ]
+        sqla-version: ['1.3.24', '1.4.45']
 
     steps:
       - name: Checkout
@@ -47,6 +49,7 @@ jobs:
       - name: Install project
         run: |
           pip install --editable=.[sqlalchemy,test,doc]
+          pip install "sqlalchemy==${{ matrix.sqla-version }}" --upgrade --pre
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
GH-498 displayed multiple admonitions from the CodeQL scan, because the test environment wasn't populated properly with different SQLAlchemy versions. Let's try it again by adding the SQLAlchemy version to the corresponding test matrix.

![image](https://user-images.githubusercontent.com/453543/209472123-d122ac4f-b547-4e1e-96b2-1a170c72b011.png)
