### PR TITLE
SQLAlchemy: Clean up `CrateCompiler`

### DIFF
--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -208,8 +208,6 @@ class CrateTypeCompiler(compiler.GenericTypeCompiler):
 
 class CrateCompiler(compiler.SQLCompiler):
 
-    prefetch = []
-
     def visit_getitem_binary(self, binary, operator, **kw):
         return "{0}['{1}']".format(
             self.process(binary.left, **kw),

--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -224,11 +224,10 @@ class CrateCompiler(compiler.SQLCompiler):
         )
 
     def returning_clause(self, stmt, returning_cols):
-        columns = [
-            self._label_select_column(None, c, True, False, {})
-            for c in sa.sql.expression._select_iterables(returning_cols)
-        ]
-        return "RETURNING " + ", ".join(columns)
+        """
+        Generate RETURNING clause, PostgreSQL-compatible.
+        """
+        return PGCompiler.returning_clause(self, stmt, returning_cols)
 
     def visit_update(self, update_stmt, **kw):
         """


### PR DESCRIPTION
While working on the other refactorings and improvements, I discovered two spots that could be optimized.