### PR TITLE
Documentation: Fix broken links

### DIFF
--- a/docs/connect.rst
+++ b/docs/connect.rst
@@ -270,6 +270,6 @@ Once you're connected, you can :ref:`query CrateDB <query>`.
 .. _client-side random load balancing: https://en.wikipedia.org/wiki/Load_balancing_(computing)#Client-side_random_load_balancing
 .. _Python Database API Specification v2.0: https://www.python.org/dev/peps/pep-0249/
 .. _round-robin DNS: https://en.wikipedia.org/wiki/Round-robin_DNS
-.. _sample application: https://github.com/crate/crate-sample-apps/tree/master/python
-.. _sample application documentation: https://github.com/crate/crate-sample-apps/blob/master/python/documentation.md
+.. _sample application: https://github.com/crate/crate-sample-apps/tree/main/python-flask
+.. _sample application documentation: https://github.com/crate/crate-sample-apps/blob/main/python-flask/documentation.md
 .. _SQLAlchemy: https://www.sqlalchemy.org/

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,8 +15,9 @@ It also includes the :ref:`CrateDB dialect <using-sqlalchemy>` for `SQLAlchemy`_
 
     This is a basic CrateDB driver reference.
 
-    Check out the `sample application`_ (and the corresponding `documentation`_)
-    for a practical demonstration of this driver in use.
+    Check out the `sample application`_ (and the corresponding `sample
+    application documentation`_) for a practical demonstration of this driver
+    in use.
 
     For general help using the Python Database API or SQLAlchemy, please consult
     `PEP 249`_, the `SQLAlchemy tutorial`_, or the `SQLAlchemy documentation`_.
@@ -40,11 +41,11 @@ It also includes the :ref:`CrateDB dialect <using-sqlalchemy>` for `SQLAlchemy`_
    appendices/index
 
 .. _CrateDB: https://crate.io/products/cratedb/
-.. _documentation: https://github.com/crate/crate-sample-apps/blob/master/python/documentation.md
 .. _hosted on GitHub: https://github.com/crate/crate-python
 .. _PEP 249: https://www.python.org/dev/peps/pep-0249/
 .. _Python Database API Specification v2.0: https://www.python.org/dev/peps/pep-0249/
-.. _sample application: https://github.com/crate/crate-sample-apps/tree/master/python
+.. _sample application: https://github.com/crate/crate-sample-apps/tree/main/python-flask
+.. _sample application documentation: https://github.com/crate/crate-sample-apps/blob/main/python-flask/documentation.md
 .. _SQLAlchemy: https://www.sqlalchemy.org/
 .. _SQLAlchemy documentation: https://docs.sqlalchemy.org/
 .. _SQLAlchemy tutorial: https://docs.sqlalchemy.org/en/latest/orm/tutorial.html


### PR DESCRIPTION
Within the documentation, this patch fixes broken links after renaming folders at https://github.com/crate/crate-sample-apps/pull/95.