### PR TITLE
CI: Fix CodeQL definition

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -54,4 +54,4 @@ jobs:
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2
         with:
-          category: "/language:${{ matrix.language }}"
+          category: "/language:${{ matrix.language }}/sqla-version:${{ matrix.sqla-version }}"


### PR DESCRIPTION
### About
This patch fixes the CodeQL job definition regarding SQLAlchemy package mismatches when running a test matrix on different SQLAlchemy versions.

### Details
The CodeQL job definition lacked an appropriate setting for the `category` parameter.

https://github.com/crate/crate-python/blob/696a6239afd28ce6dd52988f65aa511e50629fa8/.github/workflows/codeql.yml#L54-L57

When introducing a matrix axis (here: `sqla-version`), you will have to teach code scanning about it.

https://github.com/crate/crate-python/blob/696a6239afd28ce6dd52988f65aa511e50629fa8/.github/workflows/codeql.yml#L29-L33

Otherwise, it will be obvious that code scanning will get confused by different versions of dependencies.

https://github.com/crate/crate-python/blob/696a6239afd28ce6dd52988f65aa511e50629fa8/.github/workflows/codeql.yml#L49-L52

### Solution
https://github.com/crate/crate-python/blob/60b0092980796384ff370dc39023f95a00e532b8/.github/workflows/codeql.yml#L54-L57

### Credits
This has been discovered by @anaarmas from the CodeQL team [^1]. Thanks a stack!

[^1]: https://github.com/github/codeql-action/issues/1411#issuecomment-1400697265