### PR TITLE
SQLAlchemy: Don't use deprecated `_ConnectionFairy.connection` attribute

### DIFF
--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -24,7 +24,7 @@ see, for example, `useful command-line options for zope-testrunner`_.
 
 Run all tests::
 
-    ./bin/test
+    ./bin/test -vvvv
 
 Run specific tests::
 

--- a/src/crate/client/sqlalchemy/compat/api13.py
+++ b/src/crate/client/sqlalchemy/compat/api13.py
@@ -131,3 +131,26 @@ def monkeypatch_amend_select_sa14():
     sqlalchemy.select = select_sa14
     sqlalchemy.sql.select = select_sa14
     sqlalchemy.sql.expression.select = select_sa14
+
+
+@property
+def connectionfairy_driver_connection_sa14(self):
+    """The connection object as returned by the driver after a connect.
+
+    .. versionadded:: 1.4.24
+
+    .. seealso::
+
+        :attr:`._ConnectionFairy.dbapi_connection`
+
+        :attr:`._ConnectionRecord.driver_connection`
+
+        :ref:`faq_dbapi_connection`
+
+    """
+    return self.connection
+
+
+def monkeypatch_add_connectionfairy_driver_connection():
+    import sqlalchemy.pool.base
+    sqlalchemy.pool.base._ConnectionFairy.driver_connection = connectionfairy_driver_connection_sa14

--- a/src/crate/client/sqlalchemy/tests/__init__.py
+++ b/src/crate/client/sqlalchemy/tests/__init__.py
@@ -1,12 +1,13 @@
 # -*- coding: utf-8 -*-
 
-from ..compat.api13 import monkeypatch_amend_select_sa14
+from ..compat.api13 import monkeypatch_amend_select_sa14, monkeypatch_add_connectionfairy_driver_connection
 from ..sa_version import SA_1_4, SA_VERSION
 
 # `sql.select()` of SQLAlchemy 1.3 uses old calling semantics,
 # but the test cases already need the modern ones.
 if SA_VERSION < SA_1_4:
     monkeypatch_amend_select_sa14()
+    monkeypatch_add_connectionfairy_driver_connection()
 
 from unittest import TestSuite, makeSuite
 from .connection_test import SqlAlchemyConnectionTest

--- a/src/crate/client/sqlalchemy/tests/connection_test.py
+++ b/src/crate/client/sqlalchemy/tests/connection_test.py
@@ -34,7 +34,7 @@ class SqlAlchemyConnectionTest(TestCase):
         engine = sa.create_engine('crate://')
         conn = engine.raw_connection()
         self.assertEqual("<Connection <Client ['http://127.0.0.1:4200']>>",
-                         repr(conn.connection))
+                         repr(conn.driver_connection))
         conn.close()
         engine.dispose()
 
@@ -43,7 +43,7 @@ class SqlAlchemyConnectionTest(TestCase):
             "crate://otherhost:19201")
         conn = engine.raw_connection()
         self.assertEqual("<Connection <Client ['http://otherhost:19201']>>",
-                         repr(conn.connection))
+                         repr(conn.driver_connection))
         conn.close()
         engine.dispose()
 
@@ -52,7 +52,7 @@ class SqlAlchemyConnectionTest(TestCase):
             "crate://otherhost:19201/?ssl=true")
         conn = engine.raw_connection()
         self.assertEqual("<Connection <Client ['https://otherhost:19201']>>",
-                         repr(conn.connection))
+                         repr(conn.driver_connection))
         conn.close()
         engine.dispose()
 
@@ -66,9 +66,9 @@ class SqlAlchemyConnectionTest(TestCase):
             "crate://foo@otherhost:19201/?ssl=true")
         conn = engine.raw_connection()
         self.assertEqual("<Connection <Client ['https://otherhost:19201']>>",
-                         repr(conn.connection))
-        self.assertEqual(conn.connection.client.username, "foo")
-        self.assertEqual(conn.connection.client.password, None)
+                         repr(conn.driver_connection))
+        self.assertEqual(conn.driver_connection.client.username, "foo")
+        self.assertEqual(conn.driver_connection.client.password, None)
         conn.close()
         engine.dispose()
 
@@ -77,9 +77,9 @@ class SqlAlchemyConnectionTest(TestCase):
             "crate://foo:bar@otherhost:19201/?ssl=true")
         conn = engine.raw_connection()
         self.assertEqual("<Connection <Client ['https://otherhost:19201']>>",
-                         repr(conn.connection))
-        self.assertEqual(conn.connection.client.username, "foo")
-        self.assertEqual(conn.connection.client.password, "bar")
+                         repr(conn.driver_connection))
+        self.assertEqual(conn.driver_connection.client.username, "foo")
+        self.assertEqual(conn.driver_connection.client.password, "bar")
         conn.close()
         engine.dispose()
 
@@ -93,7 +93,7 @@ class SqlAlchemyConnectionTest(TestCase):
         self.assertEqual(
             "<Connection <Client ['http://localhost:4201', " +
             "'http://localhost:4202']>>",
-            repr(conn.connection))
+            repr(conn.driver_connection))
         conn.close()
         engine.dispose()
 
@@ -108,6 +108,6 @@ class SqlAlchemyConnectionTest(TestCase):
         self.assertEqual(
             "<Connection <Client ['https://localhost:4201', " +
             "'https://localhost:4202']>>",
-            repr(conn.connection))
+            repr(conn.driver_connection))
         conn.close()
         engine.dispose()


### PR DESCRIPTION
### About

SQLAlchemy's `_ConnectionFairy.connection` attribute will be become deprecated.

> SADeprecationWarning: The _ConnectionFairy.connection attribute is deprecated; please use 'driver_connection' (deprecated since: 2.0)

### Solution
1. Just use `driver_connection` instead.
2. For SA13, addtionally back-port it.
