### PR TITLE
SQLAlchemy: Implement `CrateDialect.import_dbapi` alongside `.dbapi`

### DIFF
--- a/src/crate/client/sqlalchemy/dialect.py
+++ b/src/crate/client/sqlalchemy/dialect.py
@@ -219,9 +219,13 @@ class CrateDialect(default.DefaultDialect):
         return tuple(connection.connection.lowest_server_version.version)
 
     @classmethod
-    def dbapi(cls):
+    def import_dbapi(cls):
         from crate import client
         return client
+
+    @classmethod
+    def dbapi(cls):
+        return cls.import_dbapi()
 
     def has_schema(self, connection, schema):
         return schema in self.get_schema_names(connection)


### PR DESCRIPTION
### About

The `dbapi()` classmethod on dialect classes has been renamed to `import_dbapi()`.

> SADeprecationWarning: The dbapi() classmethod on dialect classes has been renamed to import_dbapi().  Implement an import_dbapi() classmethod directly on class 'CrateDialect' to remove this warning; the old .dbapi() classmethod may be maintained for backwards compatibility.

### Solution

Just followed the suggestion 1:1.
