### PR TITLE
Maintenance: Address update suggestions by Dependabot

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-zc.buildout==2.13.8
+zc.buildout==3.0.1

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ setup(
                     'geojson>=2.5.0,<4',
                     'backports.zoneinfo<1; python_version<"3.9"'],
         test=['tox>=3,<5',
-              'zope.testing>=4,<5',
+              'zope.testing>=4,<6',
               'zope.testrunner>=5,<6',
               'zc.customdoctests>=1.0.1,<2',
               'createcoverage>=1,<2',

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ setup(
               'zc.customdoctests>=1.0.1,<2',
               'createcoverage>=1,<2',
               'stopit>=1.1.2,<2',
-              'flake8>=4,<5',
+              'flake8>=4,<7',
               'pytz',
               # `test_http.py` needs `setuptools.ssl_support`
               'setuptools<57',

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ setup(
         sqlalchemy=['sqlalchemy>=1.0,<2.1',
                     'geojson>=2.5.0,<4',
                     'backports.zoneinfo<1; python_version<"3.9"'],
-        test=['tox>=3,<4',
+        test=['tox>=3,<5',
               'zope.testing>=4,<5',
               'zope.testrunner>=5,<6',
               'zc.customdoctests>=1.0.1,<2',

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,10 @@ setup(
               'createcoverage>=1,<2',
               'stopit>=1.1.2,<2',
               'flake8>=4,<5',
-              'pytz'],
+              'pytz',
+              # `test_http.py` needs `setuptools.ssl_support`
+              'setuptools<57',
+              ],
         doc=['sphinx>=3.5,<6',
              'crate-docs-theme>=0.26.5'],
     ),

--- a/setup.py
+++ b/setup.py
@@ -74,7 +74,7 @@ setup(
               # `test_http.py` needs `setuptools.ssl_support`
               'setuptools<57',
               ],
-        doc=['sphinx>=3.5,<6',
+        doc=['sphinx>=3.5,<7',
              'crate-docs-theme>=0.26.5'],
     ),
     python_requires='>=3.4',


### PR DESCRIPTION
This PR collects all the individual patches just submitted by Dependabot, accompanied by a little fix 692697e8fd to satisfy the test suite with a specific version of `setuptools<57`. Dependabot will probably submit another patch to bump this specific version again, which can then be addressed separately.

- GH-517
- GH-518
- GH-519
- GH-520
- GH-521