### PR TITLE
Dependencies: Limit installation to `urllib3<2`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
             'crate = crate.client.sqlalchemy:CrateDialect'
         ]
     },
-    install_requires=['urllib3>=1.9,<3'],
+    install_requires=['urllib3>=1.9,<2'],
     extras_require=dict(
         sqlalchemy=['sqlalchemy>=1.0,<2.1',
                     'geojson>=2.5.0,<4',


### PR DESCRIPTION
We learned that, when installing the upcoming `urllib3-2.0.0`, it would effectively drop support for TLS 1.0 and 1.1 by default, and `crate-python` does not offer corresponding fallback adjustments yet. In order not to break things too sloppily, let us postpone this transition, in the spirit of "better safe than sorry".

> If you still need to use TLS 1.0 or 1.1 in your application you can still upgrade to v2.0, you’ll only need to set `ssl_minimum_version` to the proper value to continue using legacy TLS versions.
>
> -- https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html#modern-security-by-default

In order to follow up on this, I've created GH-526.

/cc @seut 