### PR TITLE
SA20: Fix `unexpected keyword argument 'info_cache'` on introspection

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Changes for crate
 Unreleased
 ==========
 
+- Fixed SQLAlchemy 2.0 incompatibility with ``CrateDialect.{has_schema,has_table}``
 
 2023/02/16 0.30.0
 =================

--- a/src/crate/client/sqlalchemy/dialect.py
+++ b/src/crate/client/sqlalchemy/dialect.py
@@ -227,11 +227,11 @@ class CrateDialect(default.DefaultDialect):
     def dbapi(cls):
         return cls.import_dbapi()
 
-    def has_schema(self, connection, schema):
-        return schema in self.get_schema_names(connection)
+    def has_schema(self, connection, schema, **kw):
+        return schema in self.get_schema_names(connection, **kw)
 
-    def has_table(self, connection, table_name, schema=None):
-        return table_name in self.get_table_names(connection, schema=schema)
+    def has_table(self, connection, table_name, schema=None, **kw):
+        return table_name in self.get_table_names(connection, schema=schema, **kw)
 
     @reflection.cache
     def get_schema_names(self, connection, **kw):


### PR DESCRIPTION
Both methods `CrateDialect.{has_schema,has_table}` need to accept and forward keyword arguments, in order to comply to the intended interface, starting with SQLAlchemy 2.0.

Otherwise, those exceptions would be raised:
```python
TypeError: CrateDialect.has_schema() got an unexpected keyword argument 'info_cache'
TypeError: CrateDialect.has_table() got an unexpected keyword argument 'info_cache'
```

The flaw has been discovered when using SQLAlchemy 2.x to evaluate this snippet, using pandas.

```python
import pandas as pd
import sqlalchemy as sa

engine = sa.create_engine("crate://localhost:4200")
df = pd.DataFrame.from_records([{"foo": "baz", "bar": "qux"}])
df.to_sql(name="testdrive", con=engine, if_exists="replace", index=False)
```
