### PR TITLE
SQLAlchemy: Support `INSERT...VALUES` with multiple value sets

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for crate
 Unreleased
 ==========
 
+- SQLAlchemy: Support ``INSERT...VALUES`` with multiple value sets by enabling
+  ``supports_multivalues_insert`` on the CrateDB dialect, it is used by pandas'
+  ``method="multi"`` option
+
 
 2023/03/02 0.30.1
 =================

--- a/src/crate/client/sqlalchemy/dialect.py
+++ b/src/crate/client/sqlalchemy/dialect.py
@@ -169,9 +169,11 @@ else:
 class CrateDialect(default.DefaultDialect):
     name = 'crate'
     driver = 'crate-python'
+    default_paramstyle = 'qmark'
     statement_compiler = statement_compiler
     ddl_compiler = CrateDDLCompiler
     type_compiler = CrateTypeCompiler
+    supports_multivalues_insert = True
     supports_native_boolean = True
     supports_statement_cache = True
     colspecs = colspecs


### PR DESCRIPTION
Enable `supports_multivalues_insert` on the CrateDB dialect, mitigating the error reported at GH-534:

    CompileError: The 'crate' dialect with current database version
    settings does not support in-place multirow inserts

> The Insert construct also supports being passed a list of dictionaries
> or full-table-tuples, which on the server will render the less common
> SQL syntax of "multiple values" - this syntax is supported on backends
> such as SQLite, PostgreSQL, MySQL, but not necessarily others.

> It is essential to note that passing multiple values is NOT the same
> as using traditional `executemany()` form. The above syntax is a special
> syntax not typically used. To emit an INSERT statement against
> multiple rows, the normal method is to pass a multiple values list to
> the `Connection.execute()` method [^1], which is supported by all database
> backends and is generally more efficient for a very large number of
> parameters [^2].

-- https://docs.sqlalchemy.org/core/dml.html#sqlalchemy.sql.expression.Insert.values.params.*args

[^1]: [Introduction to the traditional Core method of multiple parameter set invocation for INSERTs and other statements](https://docs.sqlalchemy.org/tutorial/dbapi_transactions.html#tutorial-multiple-parameters)
[^2]: With this method, there is curently an issue reported at GH-537.

/cc @SStorm, @WalBeh, @seut 