### PR TITLE
Documentation: Use more specific queries for landing page examples, and remove idiomatic REPL prompt

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -111,8 +111,11 @@ Connect to CrateDB instance running on ``localhost``.
 .. code-block:: python
 
     # Connect using SQLAlchemy Core.
+    import pkg_resources
     import sqlalchemy as sa
     from pprint import pp
+
+    pkg_resources.require("sqlalchemy>=2.0")
     
     dburi = "crate://localhost:4200"
     query = "SELECT country, mountain, coordinates, height FROM sys.summits ORDER BY country;"

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,34 +58,34 @@ Install package from PyPI.
 
 .. code-block:: shell
 
-    $ pip install crate
+    pip install crate
 
 Connect to CrateDB instance running on ``localhost``.
 
 .. code-block:: python
 
-    >>> # Connect using DB API.
-    >>> from pprint import pp
-    >>> from crate import client
-    >>>
-    >>> query = "SELECT country, mountain, coordinates, height FROM sys.summits ORDER BY country;"
-    >>>
-    >>> with client.connect("localhost:4200", username="crate") as connection:
-    ...     cursor = connection.cursor()
-    ...     cursor.execute(query)
-    ...     pp(cursor.fetchall())
-    ...     cursor.close()
+    # Connect using DB API.
+    from crate import client
+    from pprint import pp
+
+    query = "SELECT country, mountain, coordinates, height FROM sys.summits ORDER BY country;"
+    
+    with client.connect("localhost:4200", username="crate") as connection:
+        cursor = connection.cursor()
+        cursor.execute(query)
+        pp(cursor.fetchall())
+        cursor.close()
 
 Connect to `CrateDB Cloud`_.
 
 .. code-block:: python
 
-    >>> # Connect using DB API.
-    >>> from crate import client
-    >>> connection = client.connect(
-    ...     servers="https://example.aks1.westeurope.azure.cratedb.net:4200",
-    ...     username="admin",
-    ...     password="<PASSWORD>")
+    # Connect using DB API.
+    from crate import client
+    connection = client.connect(
+        servers="https://example.aks1.westeurope.azure.cratedb.net:4200",
+        username="admin",
+        password="<PASSWORD>")
 
 
 SQLAlchemy
@@ -104,49 +104,49 @@ Install package from PyPI with DB API and SQLAlchemy support.
 
 .. code-block:: shell
 
-    $ pip install 'crate[sqlalchemy]' pandas
+    pip install 'crate[sqlalchemy]' pandas
 
 Connect to CrateDB instance running on ``localhost``.
 
 .. code-block:: python
 
-    >>> # Connect using SQLAlchemy Core.
-    >>> from pprint import pp
-    >>> import sqlalchemy as sa
-    >>>
-    >>> dburi = "crate://localhost:4200"
-    >>> query = "SELECT country, mountain, coordinates, height FROM sys.summits ORDER BY country;"
-    >>>
-    >>> engine = sa.create_engine(dburi, echo=True)
-    >>> with engine.connect() as connection:
-    ...     with connection.execute(sa.text(query)) as result:
-    ...         pp(result.mappings().fetchall())
+    # Connect using SQLAlchemy Core.
+    import sqlalchemy as sa
+    from pprint import pp
+    
+    dburi = "crate://localhost:4200"
+    query = "SELECT country, mountain, coordinates, height FROM sys.summits ORDER BY country;"
+    
+    engine = sa.create_engine(dburi, echo=True)
+    with engine.connect() as connection:
+        with connection.execute(sa.text(query)) as result:
+            pp(result.mappings().fetchall())
 
 Connect to `CrateDB Cloud`_.
 
 .. code-block:: python
 
-    >>> # Connect using SQLAlchemy Core.
-    >>> import sqlalchemy as sa
-    >>> dburi = "crate://admin:<PASSWORD>@example.aks1.westeurope.azure.cratedb.net:4200?ssl=true"
-    >>> engine = sa.create_engine(dburi, echo=True)
+    # Connect using SQLAlchemy Core.
+    import sqlalchemy as sa
+    dburi = "crate://admin:<PASSWORD>@example.aks1.westeurope.azure.cratedb.net:4200?ssl=true"
+    engine = sa.create_engine(dburi, echo=True)
 
 Load results into `pandas`_ DataFrame.
 
 .. code-block:: python
 
-    >>> # Connect using SQLAlchemy Core and pandas.
-    >>> import pandas as pd
-    >>> import sqlalchemy as sa
-    >>>
-    >>> dburi = "crate://localhost:4200"
-    >>> query = "SELECT * FROM sys.summits ORDER BY country;"
-    >>>
-    >>> engine = sa.create_engine(dburi, echo=True)
-    >>> with engine.connect() as connection:
-    ...     df = pd.read_sql(sql=sa.text(query), con=connection)
-    ...     df.info()
-    ...     print(df)
+    # Connect using SQLAlchemy Core and pandas.
+    import pandas as pd
+    import sqlalchemy as sa
+    
+    dburi = "crate://localhost:4200"
+    query = "SELECT * FROM sys.summits ORDER BY country;"
+    
+    engine = sa.create_engine(dburi, echo=True)
+    with engine.connect() as connection:
+        df = pd.read_sql(sql=sa.text(query), con=connection)
+        df.info()
+        print(df)
 
 
 Data types

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,12 +65,16 @@ Connect to CrateDB instance running on ``localhost``.
 .. code-block:: python
 
     >>> # Connect using DB API.
+    >>> from pprint import pp
     >>> from crate import client
+    >>>
+    >>> query = "SELECT country, mountain, coordinates, height FROM sys.summits ORDER BY country;"
+    >>>
     >>> with client.connect("localhost:4200", username="crate") as connection:
-    >>>     cursor = connection.cursor()
-    >>>     cursor.execute("SELECT * FROM sys.summits;")
-    >>>     print(cursor.fetchall())
-    >>>     cursor.close()
+    ...     cursor = connection.cursor()
+    ...     cursor.execute(query)
+    ...     pp(cursor.fetchall())
+    ...     cursor.close()
 
 Connect to `CrateDB Cloud`_.
 
@@ -107,11 +111,16 @@ Connect to CrateDB instance running on ``localhost``.
 .. code-block:: python
 
     >>> # Connect using SQLAlchemy Core.
+    >>> from pprint import pp
     >>> import sqlalchemy as sa
-    >>> engine = sa.create_engine("crate://localhost:4200", echo=True)
+    >>>
+    >>> dburi = "crate://localhost:4200"
+    >>> query = "SELECT country, mountain, coordinates, height FROM sys.summits ORDER BY country;"
+    >>>
+    >>> engine = sa.create_engine(dburi, echo=True)
     >>> with engine.connect() as connection:
-    >>>     with connection.execute(sa.text("SELECT * FROM sys.summits;")) as cursor:
-    >>>         print(cursor.fetchall())
+    ...     with connection.execute(sa.text(query)) as result:
+    ...         pp(result.mappings().fetchall())
 
 Connect to `CrateDB Cloud`_.
 
@@ -129,11 +138,15 @@ Load results into `pandas`_ DataFrame.
     >>> # Connect using SQLAlchemy Core and pandas.
     >>> import pandas as pd
     >>> import sqlalchemy as sa
-    >>> engine = sa.create_engine("crate://localhost:4200", echo=True)
+    >>>
+    >>> dburi = "crate://localhost:4200"
+    >>> query = "SELECT * FROM sys.summits ORDER BY country;"
+    >>>
+    >>> engine = sa.create_engine(dburi, echo=True)
     >>> with engine.connect() as connection:
-    >>>     df = pd.read_sql(sql=sa.text("SELECT * FROM sys.summits;"), con=connection)
-    >>>     df.info()
-    >>>     print(df)
+    ...     df = pd.read_sql(sql=sa.text(query), con=connection)
+    ...     df.info()
+    ...     print(df)
 
 
 Data types


### PR DESCRIPTION
As suggested by @hlcianfagna, 84f29fc0f6 brings in more specific queries on the `sys.summits` table, in order to produce more pleasant output. Thanks! Other than this, the patch also removes idiomatic Python-REPL prompts with 30b06e563.

### DB API
```python
[['AT', 'Großglockner', [12.69444, 47.07417], 3798],
 ['AT', 'Wildspitze', [10.86722, 46.88528], 3770],
 ['AT', 'Großvenediger', [12.34639, 47.10917], 3666],
 ['AT', 'Großes Wiesbachhorn', [12.75528, 47.15639], 3564],
 ['AT', 'Großer Ramolkogel', [10.95889, 46.84667], 3550],
 ['AT', 'Schalfkogel', [10.95917, 46.80167], 3540],
 ['AT', 'Hochvernagtspitze', [10.79611, 46.88139], 3535],
[...]
```

### SQLAlchemy
```python
[{'country': 'AT', 'mountain': 'Großglockner', 'coordinates': [12.69444, 47.07417], 'height': 3798},
 {'country': 'AT', 'mountain': 'Wildspitze', 'coordinates': [10.86722, 46.88528], 'height': 3770},
 {'country': 'AT', 'mountain': 'Großvenediger', 'coordinates': [12.34639, 47.10917], 'height': 3666},
 {'country': 'AT', 'mountain': 'Großes Wiesbachhorn', 'coordinates': [12.75528, 47.15639], 'height': 3564},
 {'country': 'AT', 'mountain': 'Großer Ramolkogel', 'coordinates': [10.95889, 46.84667], 'height': 3550},
 {'country': 'AT', 'mountain': 'Schalfkogel', 'coordinates': [10.95917, 46.80167], 'height': 3540},
 {'country': 'AT', 'mountain': 'Hochvernagtspitze', 'coordinates': [10.79611, 46.88139], 'height': 3535},
[...]
```
