### PR TITLE
Release 0.31.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for crate
 Unreleased
 ==========
 
+
+2023/03/30 0.31.0
+=================
+
 - SQLAlchemy Core: Support ``INSERT...VALUES`` with multiple value sets by enabling
   ``supports_multivalues_insert`` on the CrateDB dialect, it is used by pandas'
   ``method="multi"`` option

--- a/src/crate/client/__init__.py
+++ b/src/crate/client/__init__.py
@@ -29,7 +29,7 @@ __all__ = [
 
 # version string read from setup.py using a regex. Take care not to break the
 # regex!
-__version__ = "0.30.1"
+__version__ = "0.31.0"
 
 apilevel = "2.0"
 threadsafety = 2


### PR DESCRIPTION
Release the latest updates for improving insert performance/efficiency with pandas, Dask, and friends.

- GH-538
- GH-539

This resolves two issues reported the other day.

- GH-534
- GH-537

/cc @hammerhead, @proddata, @hlcianfagna, @marijaselakovic, @fafahimi 