### PR TITLE
Edit the robots to stop the readthedocs page from being indexed

### DIFF
--- a/docs/_extra/robots.txt
+++ b/docs/_extra/robots.txt
@@ -1,2 +1,4 @@
-Sitemap: https://crate.io/docs/python/en/latest/site.xml
 User-agent: *
+Disallow: /
+
+Sitemap: https://crate.io/docs/python/en/latest/site.xml


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement


## Checklist

 - [ ] [CLA](https://crate.io/community/contribute/cla/) is signed
