### PR TITLE
SQLAlchemy/DDL: Allow to turn off column store

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crate
 Unreleased
 ==========
 
+- SQLAlchemy DDL: Allow turning off column store using ``crate_columnstore=False``.
+  Thanks, @fetzerms.
+
 
 2023/04/18 0.31.1
 =================

--- a/docs/sqlalchemy.rst
+++ b/docs/sqlalchemy.rst
@@ -205,6 +205,7 @@ system <sa:orm_declarative_mapping>`:
     ...     more_details = sa.Column(types.ObjectArray)
     ...     name_ft = sa.Column(sa.String)
     ...     quote_ft = sa.Column(sa.String)
+    ...     even_more_details = sa.Column(sa.String, crate_columnstore=False)
     ...
     ...     __mapper_args__ = {
     ...         'exclude_properties': ['name_ft', 'quote_ft']
@@ -220,6 +221,7 @@ In this example, we:
 - Use standard SQLAlchemy types for the ``id``, ``name``, and ``quote`` columns
 - Use ``nullable=False`` to define a ``NOT NULL`` constraint
 - Disable indexing of the ``name`` column using ``crate_index=False``
+- Disable the columnstore of the ``even_more_details`` column using ``crate_columnstore=False``
 - Define a computed column ``name_normalized`` (based on ``name``) that
   translates into a generated column
 - Use the `Object`_ extension type for the ``details`` column

--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -128,6 +128,9 @@ class CrateDDLCompiler(compiler.DDLCompiler):
 
             colspec += " INDEX OFF"
 
+        if column.dialect_options['crate'].get('columnstore') is False:
+            colspec += " STORAGE WITH (columnstore = false)"
+
         return colspec
 
     def visit_computed_column(self, generated):

--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -25,6 +25,7 @@ from collections import defaultdict
 import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql.base import PGCompiler
 from sqlalchemy.sql import compiler
+from sqlalchemy.types import String
 from .types import MutableDict, _Craty, Geopoint, Geoshape
 from .sa_version import SA_VERSION, SA_1_4
 
@@ -129,6 +130,11 @@ class CrateDDLCompiler(compiler.DDLCompiler):
             colspec += " INDEX OFF"
 
         if column.dialect_options['crate'].get('columnstore') is False:
+            if not isinstance(column.type, (String, )):
+                raise sa.exc.CompileError(
+                    "Controlling the columnstore is only allowed for STRING columns"
+                )
+
             colspec += " STORAGE WITH (columnstore = false)"
 
         return colspec

--- a/src/crate/client/sqlalchemy/tests/create_table_test.py
+++ b/src/crate/client/sqlalchemy/tests/create_table_test.py
@@ -20,7 +20,6 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import sqlalchemy as sa
-
 try:
     from sqlalchemy.orm import declarative_base
 except ImportError:
@@ -31,6 +30,7 @@ from crate.client.cursor import Cursor
 
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
+
 
 fake_cursor = MagicMock(name='fake_cursor')
 FakeCursor = MagicMock(name='FakeCursor', spec=Cursor)
@@ -77,7 +77,6 @@ class SqlAlchemyCreateTableTest(TestCase):
             __tablename__ = 'dummy'
             pk = sa.Column(sa.String, primary_key=True)
             obj_col = sa.Column(Object)
-
         self.Base.metadata.create_all(bind=self.engine)
         fake_cursor.execute.assert_called_with(
             ('\nCREATE TABLE dummy (\n\tpk STRING NOT NULL, \n\tobj_col OBJECT, '
@@ -92,7 +91,6 @@ class SqlAlchemyCreateTableTest(TestCase):
             }
             pk = sa.Column(sa.String, primary_key=True)
             p = sa.Column(sa.String)
-
         self.Base.metadata.create_all(bind=self.engine)
         fake_cursor.execute.assert_called_with(
             ('\nCREATE TABLE t (\n\t'
@@ -107,7 +105,6 @@ class SqlAlchemyCreateTableTest(TestCase):
             __tablename__ = 't'
             ts = sa.Column(sa.BigInteger, primary_key=True)
             p = sa.Column(sa.BigInteger, sa.Computed("date_trunc('day', ts)"))
-
         self.Base.metadata.create_all(bind=self.engine)
         fake_cursor.execute.assert_called_with(
             ('\nCREATE TABLE t (\n\t'
@@ -122,7 +119,6 @@ class SqlAlchemyCreateTableTest(TestCase):
             __tablename__ = 't'
             ts = sa.Column(sa.BigInteger, primary_key=True)
             p = sa.Column(sa.BigInteger, sa.Computed("date_trunc('day', ts)", persisted=False))
-
         with self.assertRaises(sa.exc.CompileError):
             self.Base.metadata.create_all(bind=self.engine)
 
@@ -135,7 +131,6 @@ class SqlAlchemyCreateTableTest(TestCase):
             }
             pk = sa.Column(sa.String, primary_key=True)
             p = sa.Column(sa.String)
-
         self.Base.metadata.create_all(bind=self.engine)
         fake_cursor.execute.assert_called_with(
             ('\nCREATE TABLE t (\n\t'
@@ -171,7 +166,6 @@ class SqlAlchemyCreateTableTest(TestCase):
             }
             pk = sa.Column(sa.String, primary_key=True)
             p = sa.Column(sa.String, primary_key=True)
-
         self.Base.metadata.create_all(bind=self.engine)
         fake_cursor.execute.assert_called_with(
             ('\nCREATE TABLE t (\n\t'
@@ -213,7 +207,6 @@ class SqlAlchemyCreateTableTest(TestCase):
         class DummyTable(self.Base):
             __tablename__ = 't'
             pk = sa.Column(sa.String, primary_key=True, nullable=True)
-
         with self.assertRaises(sa.exc.CompileError):
             self.Base.metadata.create_all(bind=self.engine)
 
@@ -237,7 +230,6 @@ class SqlAlchemyCreateTableTest(TestCase):
             __tablename__ = 't'
             pk = sa.Column(sa.String, primary_key=True)
             a = sa.Column(Geopoint, crate_index=False)
-
         with self.assertRaises(sa.exc.CompileError):
             self.Base.metadata.create_all(bind=self.engine)
 


### PR DESCRIPTION
### Summary of the changes / Why this is an improvement

This allows to disable column store for a text column using:
```python
my_data: str = Column(String, crate_index=False, crate_columnstore=False)
```

Which will yield:
```sql
 "my_data" TEXT INDEX OFF STORAGE WITH ( columnstore = false )
```


## Checklist

 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
