### PR TITLE
SQLAlchemy DQL: Use CrateDB's native `ILIKE` operator

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,9 @@ Unreleased
 - SQLAlchemy: Rename leftover occurrences of ``Object``. The new symbol to represent
   CrateDB's ``OBJECT`` column type is now ``ObjectType``.
 
+- SQLAlchemy DQL: Use CrateDB's native ``ILIKE`` operator instead of using SA's
+  generic implementation ``lower() LIKE lower()``. Thanks, @hlcianfagna.
+
 
 2023/07/06 0.32.0
 =================

--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -244,6 +244,40 @@ class CrateCompiler(compiler.SQLCompiler):
             self.process(element.right, **kw)
         )
 
+    def visit_ilike_case_insensitive_operand(self, element, **kw):
+        """
+        Use native `ILIKE` operator, like PostgreSQL's `PGCompiler`.
+        """
+        return element.element._compiler_dispatch(self, **kw)
+
+    def visit_ilike_op_binary(self, binary, operator, **kw):
+        """
+        Use native `ILIKE` operator, like PostgreSQL's `PGCompiler`.
+
+        Do not implement the `ESCAPE` functionality, because it is not
+        supported by CrateDB.
+        """
+        if binary.modifiers.get("escape", None) is not None:
+            raise NotImplementedError("Unsupported feature: ESCAPE is not supported")
+        return "%s ILIKE %s" % (
+            self.process(binary.left, **kw),
+            self.process(binary.right, **kw),
+        )
+
+    def visit_not_ilike_op_binary(self, binary, operator, **kw):
+        """
+        Use native `ILIKE` operator, like PostgreSQL's `PGCompiler`.
+
+        Do not implement the `ESCAPE` functionality, because it is not
+        supported by CrateDB.
+        """
+        if binary.modifiers.get("escape", None) is not None:
+            raise NotImplementedError("Unsupported feature: ESCAPE is not supported")
+        return "%s NOT ILIKE %s" % (
+            self.process(binary.left, **kw),
+            self.process(binary.right, **kw),
+        )
+
     def limit_clause(self, select, **kw):
         """
         Generate OFFSET / LIMIT clause, PostgreSQL-compatible.

--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -248,7 +248,10 @@ class CrateCompiler(compiler.SQLCompiler):
         """
         Use native `ILIKE` operator, like PostgreSQL's `PGCompiler`.
         """
-        return element.element._compiler_dispatch(self, **kw)
+        if self.dialect.has_ilike_operator():
+            return element.element._compiler_dispatch(self, **kw)
+        else:
+            return super().visit_ilike_case_insensitive_operand(element, **kw)
 
     def visit_ilike_op_binary(self, binary, operator, **kw):
         """
@@ -259,10 +262,13 @@ class CrateCompiler(compiler.SQLCompiler):
         """
         if binary.modifiers.get("escape", None) is not None:
             raise NotImplementedError("Unsupported feature: ESCAPE is not supported")
-        return "%s ILIKE %s" % (
-            self.process(binary.left, **kw),
-            self.process(binary.right, **kw),
-        )
+        if self.dialect.has_ilike_operator():
+            return "%s ILIKE %s" % (
+                self.process(binary.left, **kw),
+                self.process(binary.right, **kw),
+            )
+        else:
+            return super().visit_ilike_op_binary(binary, operator, **kw)
 
     def visit_not_ilike_op_binary(self, binary, operator, **kw):
         """
@@ -273,10 +279,13 @@ class CrateCompiler(compiler.SQLCompiler):
         """
         if binary.modifiers.get("escape", None) is not None:
             raise NotImplementedError("Unsupported feature: ESCAPE is not supported")
-        return "%s NOT ILIKE %s" % (
-            self.process(binary.left, **kw),
-            self.process(binary.right, **kw),
-        )
+        if self.dialect.has_ilike_operator():
+            return "%s NOT ILIKE %s" % (
+                self.process(binary.left, **kw),
+                self.process(binary.right, **kw),
+            )
+        else:
+            return super().visit_not_ilike_op_binary(binary, operator, **kw)
 
     def limit_clause(self, select, **kw):
         """

--- a/src/crate/client/sqlalchemy/dialect.py
+++ b/src/crate/client/sqlalchemy/dialect.py
@@ -356,6 +356,13 @@ class CrateDialect(default.DefaultDialect):
     def _resolve_type(self, type_):
         return TYPES_MAP.get(type_, sqltypes.UserDefinedType)
 
+    def has_ilike_operator(self):
+        """
+        Only CrateDB 4.1.0 and higher implements the `ILIKE` operator.
+        """
+        server_version_info = self.server_version_info
+        return server_version_info is not None and server_version_info >= (4, 1, 0)
+
 
 class DateTrunc(functions.GenericFunction):
     name = "date_trunc"

--- a/src/crate/client/sqlalchemy/tests/__init__.py
+++ b/src/crate/client/sqlalchemy/tests/__init__.py
@@ -2,6 +2,7 @@
 
 from ..compat.api13 import monkeypatch_amend_select_sa14, monkeypatch_add_connectionfairy_driver_connection
 from ..sa_version import SA_1_4, SA_VERSION
+from ...test_util import ParametrizedTestCase
 
 # `sql.select()` of SQLAlchemy 1.3 uses old calling semantics,
 # but the test cases already need the modern ones.
@@ -32,6 +33,9 @@ def test_suite_unit():
     tests.addTest(makeSuite(SqlAlchemyDictTypeTest))
     tests.addTest(makeSuite(SqlAlchemyDateAndDateTimeTest))
     tests.addTest(makeSuite(SqlAlchemyCompilerTest))
+    tests.addTest(ParametrizedTestCase.parametrize(SqlAlchemyCompilerTest, param={"server_version_info": None}))
+    tests.addTest(ParametrizedTestCase.parametrize(SqlAlchemyCompilerTest, param={"server_version_info": (4, 0, 12)}))
+    tests.addTest(ParametrizedTestCase.parametrize(SqlAlchemyCompilerTest, param={"server_version_info": (4, 1, 10)}))
     tests.addTest(makeSuite(SqlAlchemyUpdateTest))
     tests.addTest(makeSuite(SqlAlchemyMatchTest))
     tests.addTest(makeSuite(SqlAlchemyCreateTableTest))

--- a/src/crate/client/test_util.py
+++ b/src/crate/client/test_util.py
@@ -18,6 +18,7 @@
 # However, if you have executed another commercial license agreement
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
+import unittest
 
 
 class ClientMocked(object):
@@ -42,3 +43,27 @@ class ClientMocked(object):
 
     def close(self):
         pass
+
+
+class ParametrizedTestCase(unittest.TestCase):
+    """
+    TestCase classes that want to be parametrized should
+    inherit from this class.
+
+    https://eli.thegreenplace.net/2011/08/02/python-unit-testing-parametrized-test-cases
+    """
+    def __init__(self, methodName="runTest", param=None):
+        super(ParametrizedTestCase, self).__init__(methodName)
+        self.param = param
+
+    @staticmethod
+    def parametrize(testcase_klass, param=None):
+        """ Create a suite containing all tests taken from the given
+            subclass, passing them the parameter 'param'.
+        """
+        testloader = unittest.TestLoader()
+        testnames = testloader.getTestCaseNames(testcase_klass)
+        suite = unittest.TestSuite()
+        for name in testnames:
+            suite.addTest(testcase_klass(name, param=param))
+        return suite


### PR DESCRIPTION
## About

At GH-562, @hlcianfagna suggested to use CrateDB's native `ILIKE` operator instead of using SA's generic implementation `lower() LIKE lower()`.

## Details

This patch brings in the corresponding visitor methods from the `PGDialect` to the `CrateDialect` implementation.
