### PR TITLE
SQLAlchemy: Rename leftover occurrences of `Object` to `ObjectType`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,9 @@ Changes for crate
 Unreleased
 ==========
 
+- SQLAlchemy: Rename leftover occurrences of ``Object``. The new symbol to represent
+  CrateDB's ``OBJECT`` column type is now ``ObjectType``.
+
 
 2023/07/06 0.32.0
 =================

--- a/docs/by-example/sqlalchemy/working-with-types.rst
+++ b/docs/by-example/sqlalchemy/working-with-types.rst
@@ -7,7 +7,7 @@ SQLAlchemy: Working with special CrateDB types
 This section of the documentation shows how to work with special data types
 from the CrateDB SQLAlchemy dialect. Currently, these are:
 
-- Container types ``Object`` and ``ObjectArray``.
+- Container types ``ObjectType`` and ``ObjectArray``.
 - Geospatial types ``Geopoint`` and ``Geoshape``.
 
 
@@ -33,7 +33,7 @@ Import the relevant symbols:
     ... except ImportError:
     ...     from sqlalchemy.ext.declarative import declarative_base
     >>> from uuid import uuid4
-    >>> from crate.client.sqlalchemy.types import Object, ObjectArray
+    >>> from crate.client.sqlalchemy.types import ObjectType, ObjectArray
     >>> from crate.client.sqlalchemy.types import Geopoint, Geoshape
 
 Establish a connection to the database, see also :ref:`sa:engines_toplevel`
@@ -53,9 +53,9 @@ Introduction to container types
 
 In a document oriented database, it is a common pattern to store objects within
 a single field. For such cases, the CrateDB SQLAlchemy dialect provides the
-``Object`` and ``ObjectArray`` types.
+``ObjectType`` and ``ObjectArray`` types.
 
-The ``Object`` type effectively implements a dictionary- or map-like type. The
+The ``ObjectType`` type effectively implements a dictionary- or map-like type. The
 ``ObjectArray`` type maps to a Python list of dictionaries.
 
 For exercising those features, let's define a schema using SQLAlchemy's
@@ -69,15 +69,15 @@ For exercising those features, let's define a schema using SQLAlchemy's
     ...     id = sa.Column(sa.String, primary_key=True, default=gen_key)
     ...     name = sa.Column(sa.String)
     ...     quote = sa.Column(sa.String)
-    ...     details = sa.Column(Object)
+    ...     details = sa.Column(ObjectType)
     ...     more_details = sa.Column(ObjectArray)
 
 In CrateDB's SQL dialect, those container types map to :ref:`crate-reference:type-object`
 and :ref:`crate-reference:type-array`.
 
 
-``Object``
-==========
+``ObjectType``
+==============
 
 Let's add two records which have additional items within the ``details`` field.
 Note that item keys have not been defined in the DDL schema, effectively
@@ -113,7 +113,7 @@ A subsequent select query will see all the records:
     [('Arthur Dent', 'male'), ('Tricia McMillan', 'female')]
 
 It is also possible to just select a part of the document, even inside the
-``Object`` type:
+``ObjectType`` type:
 
     >>> sorted(session.query(Character.details['gender']).all())
     [('female',), ('male',)]
@@ -129,7 +129,7 @@ Update dictionary
 -----------------
 
 The SQLAlchemy CrateDB dialect supports change tracking deep down the nested
-levels of a ``Object`` type field. For example, the following query will only
+levels of a ``ObjectType`` type field. For example, the following query will only
 update the ``gender`` key. The ``species`` key which is on the same level will
 be left untouched.
 
@@ -170,7 +170,7 @@ Refresh and query "characters" table:
 ``ObjectArray``
 ===============
 
-Note that opposed to the ``Object`` type, the ``ObjectArray`` type isn't smart
+Note that opposed to the ``ObjectType`` type, the ``ObjectArray`` type isn't smart
 and doesn't have intelligent change tracking. Therefore, the generated
 ``UPDATE`` statement will affect the whole list:
 

--- a/docs/sqlalchemy.rst
+++ b/docs/sqlalchemy.rst
@@ -201,7 +201,7 @@ system <sa:orm_declarative_mapping>`:
     ...     name = sa.Column(sa.String, crate_index=False)
     ...     name_normalized = sa.Column(sa.String, sa.Computed("lower(name)"))
     ...     quote = sa.Column(sa.String, nullable=False)
-    ...     details = sa.Column(types.Object)
+    ...     details = sa.Column(types.ObjectType)
     ...     more_details = sa.Column(types.ObjectArray)
     ...     name_ft = sa.Column(sa.String)
     ...     quote_ft = sa.Column(sa.String)
@@ -224,7 +224,7 @@ In this example, we:
 - Disable indexing of the ``name`` column using ``crate_index=False``
 - Define a computed column ``name_normalized`` (based on ``name``) that
   translates into a generated column
-- Use the `Object`_ extension type for the ``details`` column
+- Use the `ObjectType`_ extension type for the ``details`` column
 - Use the `ObjectArray`_ extension type for the ``more_details`` column
 - Set up the ``name_ft`` and ``quote_ft`` fulltext indexes, but exclude them from
   the mapping (so SQLAlchemy doesn't try to update them as if they were columns)
@@ -314,9 +314,10 @@ dialect provides.
     The appendix has a full :ref:`data types reference <data-types-sqlalchemy>`.
 
 .. _object:
+.. _objecttype:
 
-``Object``
-..........
+``ObjectType``
+..............
 
 Objects are a common, and useful, data type when using CrateDB, so the CrateDB
 SQLAlchemy dialect provides a custom ``Object`` type extension for working with
@@ -355,7 +356,7 @@ insert two records:
 
 .. NOTE::
 
-    Behind the scenes, if you update an ``Object`` property and ``commit`` that
+    Behind the scenes, if you update an ``ObjectType`` property, and ``commit`` that
     change, the :ref:`UPDATE <crate-reference:dml-updating-data>` statement sent
     to CrateDB will only include the data necessary to update the changed
     sub-columns.
@@ -365,7 +366,7 @@ insert two records:
 ``ObjectArray``
 ...............
 
-In addition to the `Object`_ type, the CrateDB SQLAlchemy dialect also provides
+In addition to the `ObjectType`_ type, the CrateDB SQLAlchemy dialect also provides
 an ``ObjectArray`` type, which is structured as a :class:`py:list` of
 :class:`dictionaries <py:dict>`.
 
@@ -386,7 +387,7 @@ The resulting object will look like this:
 
 .. CAUTION::
 
-    Behind the scenes, if you update an ``ObjectArray`` and ``commit`` that
+    Behind the scenes, if you update an ``ObjectArray``, and ``commit`` that
     change, the :ref:`UPDATE <crate-reference:dml-updating-data>` statement
     sent to CrateDB will include all of the ``ObjectArray`` data.
 
@@ -468,12 +469,12 @@ Here's what a regular select might look like:
     [('Arthur Dent', 'male'), ('Tricia McMillan', 'female')]
 
 You can also select a portion of each record, and this even works inside
-`Object`_ columns:
+`ObjectType`_ columns:
 
     >>> sorted(session.query(Character.details['gender']).all())
     [('female',), ('male',)]
 
-You can also filter on attributes inside the `Object`_ column:
+You can also filter on attributes inside the `ObjectType`_ column:
 
     >>> query = session.query(Character.name)
     >>> query.filter(Character.details['gender'] == 'male').all()

--- a/src/crate/client/sqlalchemy/dialect.py
+++ b/src/crate/client/sqlalchemy/dialect.py
@@ -33,7 +33,7 @@ from .compiler import (
 )
 from crate.client.exceptions import TimezoneUnawareException
 from .sa_version import SA_VERSION, SA_1_4, SA_2_0
-from .types import Object, ObjectArray
+from .types import ObjectType, ObjectArray
 
 TYPES_MAP = {
     "boolean": sqltypes.Boolean,
@@ -41,7 +41,7 @@ TYPES_MAP = {
     "smallint": sqltypes.SmallInteger,
     "timestamp": sqltypes.TIMESTAMP,
     "timestamp with time zone": sqltypes.TIMESTAMP,
-    "object": Object,
+    "object": ObjectType,
     "integer": sqltypes.Integer,
     "long": sqltypes.NUMERIC,
     "bigint": sqltypes.NUMERIC,

--- a/src/crate/client/sqlalchemy/tests/create_table_test.py
+++ b/src/crate/client/sqlalchemy/tests/create_table_test.py
@@ -25,7 +25,7 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
-from crate.client.sqlalchemy.types import Object, ObjectArray, Geopoint
+from crate.client.sqlalchemy.types import ObjectType, ObjectArray, Geopoint
 from crate.client.cursor import Cursor
 
 from unittest import TestCase
@@ -76,7 +76,7 @@ class SqlAlchemyCreateTableTest(TestCase):
         class DummyTable(self.Base):
             __tablename__ = 'dummy'
             pk = sa.Column(sa.String, primary_key=True)
-            obj_col = sa.Column(Object)
+            obj_col = sa.Column(ObjectType)
         self.Base.metadata.create_all(bind=self.engine)
         fake_cursor.execute.assert_called_with(
             ('\nCREATE TABLE dummy (\n\tpk STRING NOT NULL, \n\tobj_col OBJECT, '

--- a/src/crate/client/sqlalchemy/tests/dialect_test.py
+++ b/src/crate/client/sqlalchemy/tests/dialect_test.py
@@ -28,7 +28,7 @@ import sqlalchemy as sa
 from crate.client.cursor import Cursor
 from crate.client.sqlalchemy import SA_VERSION
 from crate.client.sqlalchemy.sa_version import SA_1_4, SA_2_0
-from crate.client.sqlalchemy.types import Object
+from crate.client.sqlalchemy.types import ObjectType
 from sqlalchemy import inspect
 from sqlalchemy.orm import Session
 try:
@@ -67,7 +67,7 @@ class SqlAlchemyDialectTest(TestCase):
 
             name = sa.Column(sa.String, primary_key=True)
             age = sa.Column(sa.Integer, primary_key=True)
-            obj = sa.Column(Object)
+            obj = sa.Column(ObjectType)
             ts = sa.Column(sa.DateTime, onupdate=datetime.utcnow)
 
         self.session = Session(bind=self.engine)

--- a/src/crate/client/sqlalchemy/tests/query_caching.py
+++ b/src/crate/client/sqlalchemy/tests/query_caching.py
@@ -34,7 +34,7 @@ try:
 except ImportError:
     from sqlalchemy.ext.declarative import declarative_base
 
-from crate.client.sqlalchemy.types import Object, ObjectArray
+from crate.client.sqlalchemy.types import ObjectType, ObjectArray
 
 
 class SqlAlchemyQueryCompilationCaching(TestCase):
@@ -55,7 +55,7 @@ class SqlAlchemyQueryCompilationCaching(TestCase):
             __tablename__ = 'characters'
             name = sa.Column(sa.String, primary_key=True)
             age = sa.Column(sa.Integer)
-            data = sa.Column(Object)
+            data = sa.Column(ObjectType)
             data_list = sa.Column(ObjectArray)
 
         return Character

--- a/src/crate/client/sqlalchemy/tests/update_test.py
+++ b/src/crate/client/sqlalchemy/tests/update_test.py
@@ -23,7 +23,7 @@ from datetime import datetime
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
-from crate.client.sqlalchemy.types import Object
+from crate.client.sqlalchemy.types import ObjectType
 
 import sqlalchemy as sa
 from sqlalchemy.orm import Session
@@ -52,7 +52,7 @@ class SqlAlchemyUpdateTest(TestCase):
 
             name = sa.Column(sa.String, primary_key=True)
             age = sa.Column(sa.Integer)
-            obj = sa.Column(Object)
+            obj = sa.Column(ObjectType)
             ts = sa.Column(sa.DateTime, onupdate=datetime.utcnow)
 
         self.character = Character


### PR DESCRIPTION
## About

The new symbol to represent CrateDB's `OBJECT` column types is now called `ObjectType`. Before, it was just called `Object`, or sometimes `Craty`, which is both either a bit ambiguous, or a bit too fancy.
