### PR TITLE
Release 0.33.0

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,10 @@ Changes for crate
 Unreleased
 ==========
 
+
+2023/07/17 0.33.0
+=================
+
 - SQLAlchemy: Rename leftover occurrences of ``Object``. The new symbol to represent
   CrateDB's ``OBJECT`` column type is now ``ObjectType``.
 

--- a/src/crate/client/__init__.py
+++ b/src/crate/client/__init__.py
@@ -29,7 +29,7 @@ __all__ = [
 
 # version string read from setup.py using a regex. Take care not to break the
 # regex!
-__version__ = "0.32.0"
+__version__ = "0.33.0"
 
 apilevel = "2.0"
 threadsafety = 2


### PR DESCRIPTION
In order to release a cosmetic fix, and an improvement to the SQLAlchemy dialect, to support CrateDB's `ILIKE` operator.

- GH-564
- GH-565
