### PR TITLE
Added automatic conversion of UUIDs to strings.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ htmlcov/
 out/
 parts/
 tmp/
+env/

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Changes for crate
 Unreleased
 ==========
 
+- Properly handle Python-native UUID types in SQL parameters
 
 2023/07/17 0.33.0
 =================

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -35,6 +35,8 @@ from base64 import b64encode
 from time import time
 from datetime import datetime, date, timezone
 from decimal import Decimal
+from uuid import UUID
+
 from urllib3 import connection_from_url
 from urllib3.connection import HTTPConnection
 from urllib3.exceptions import (
@@ -86,7 +88,7 @@ class CrateJsonEncoder(json.JSONEncoder):
     epoch_naive = datetime(1970, 1, 1)
 
     def default(self, o):
-        if isinstance(o, Decimal):
+        if isinstance(o, (Decimal, UUID)):
             return str(o)
         if isinstance(o, datetime):
             if o.tzinfo is not None:


### PR DESCRIPTION
## About

When transport-encoding SQL parameters to JSON, Python's UUID type has not been taken into consideration. This patch intends to improve the situation.