### PR TITLE
Maintenance: This and that

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -28,7 +28,7 @@ Unreleased
 
 - Allow handling datetime values tagged with time zone info when inserting or updating.
 
-- SQLAlchemy: Fix SQL statement caching for CrateDB's ``OBJECT`` type.
+- SQLAlchemy: Fix SQL statement caching for CrateDB's ``OBJECT`` type. Thanks, @faymarie.
 
 - SQLAlchemy: Refactor ``OBJECT`` type to use SQLAlchemy's JSON type infrastructure.
 

--- a/docs/build.json
+++ b/docs/build.json
@@ -1,5 +1,5 @@
 {
   "schemaVersion": 1,
   "label": "docs build",
-  "message": "2.1.0"
+  "message": "2.1.1"
 }

--- a/docs/by-example/sqlalchemy/advanced-querying.rst
+++ b/docs/by-example/sqlalchemy/advanced-querying.rst
@@ -5,8 +5,9 @@ SQLAlchemy: Advanced querying
 =============================
 
 This section of the documentation demonstrates running queries using a fulltext
-index with analyzer, queries using counting and aggregations, and support for
-the ``INSERT...FROM SELECT`` construct, all using the CrateDB SQLAlchemy dialect.
+index with an analyzer, queries using counting and aggregations, and support for
+the ``INSERT...FROM SELECT`` and ``INSERT...RETURNING`` constructs, all using the
+CrateDB SQLAlchemy dialect.
 
 
 .. rubric:: Table of Contents

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,7 +11,7 @@ if "intersphinx_mapping" not in globals():
 
 intersphinx_mapping.update({
     'py': ('https://docs.python.org/3/', None),
-    'sa': ('https://docs.sqlalchemy.org/en/14/', None),
+    'sa': ('https://docs.sqlalchemy.org/en/20/', None),
     'urllib3': ('https://urllib3.readthedocs.io/en/1.26.13/', None),
     'dask': ('https://docs.dask.org/en/stable/', None),
     'pandas': ('https://pandas.pydata.org/docs/', None),

--- a/docs/sqlalchemy.rst
+++ b/docs/sqlalchemy.rst
@@ -28,7 +28,7 @@ The CrateDB SQLAlchemy dialect is validated to work with SQLAlchemy versions
 .. SEEALSO::
 
     For general help using SQLAlchemy, consult the :ref:`SQLAlchemy tutorial
-    <sa:ormtutorial_toplevel>` or the `SQLAlchemy library`_.
+    <sa:unified_tutorial>` or the `SQLAlchemy library`_.
 
     Supplementary information about the CrateDB SQLAlchemy dialect can be found
     in the :ref:`data types appendix <data-types-sqlalchemy>`.

--- a/src/crate/testing/layer.py
+++ b/src/crate/testing/layer.py
@@ -248,7 +248,7 @@ class CrateLayer(object):
                                         transport_port or '4300-4399',
                                         settings)
         # ES 5 cannot parse 'True'/'False' as booleans so convert to lowercase
-        start_cmd = (crate_exec, ) + tuple(["-C%s=%s" % ((key, str(value).lower()) if type(value) == bool else (key, value))
+        start_cmd = (crate_exec, ) + tuple(["-C%s=%s" % ((key, str(value).lower()) if isinstance(value, bool) else (key, value))
                                             for key, value in settings.items()])
 
         self._wd = wd = os.path.join(CrateLayer.tmpdir, 'crate_layer', name)


### PR DESCRIPTION
## About

### Update documentation content
- Add missing credits to change log
- Update to crate-docs 2.1.1
- Improve wording
- Update intersphinx reference to SQLAlchemy 2.x

### Satisfy linter admonition flake8 E721

The admonition was:
> E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()`.

Apparently, it has been added to flake8 6.1.0, released on July 29, 2023.
