### PR TITLE
Chore: Mitigate deprecation warnings about `unittest.makeSuite`

### DIFF
--- a/src/crate/client/sqlalchemy/tests/__init__.py
+++ b/src/crate/client/sqlalchemy/tests/__init__.py
@@ -10,7 +10,7 @@ if SA_VERSION < SA_1_4:
     monkeypatch_amend_select_sa14()
     monkeypatch_add_connectionfairy_driver_connection()
 
-from unittest import TestSuite, makeSuite
+from unittest import TestLoader, TestSuite
 from .connection_test import SqlAlchemyConnectionTest
 from .dict_test import SqlAlchemyDictTypeTest
 from .datetime_test import SqlAlchemyDateAndDateTimeTest
@@ -25,6 +25,9 @@ from .dialect_test import SqlAlchemyDialectTest
 from .function_test import SqlAlchemyFunctionTest
 from .warnings_test import SqlAlchemyWarningsTest
 from .query_caching import SqlAlchemyQueryCompilationCaching
+
+
+makeSuite = TestLoader().loadTestsFromTestCase
 
 
 def test_suite_unit():

--- a/src/crate/client/tests.py
+++ b/src/crate/client/tests.py
@@ -59,6 +59,8 @@ from .test_http import (
 from .sqlalchemy.tests import test_suite_unit as sqlalchemy_test_suite_unit
 from .sqlalchemy.tests import test_suite_integration as sqlalchemy_test_suite_integration
 
+makeSuite = unittest.TestLoader().loadTestsFromTestCase
+
 log = logging.getLogger('crate.testing.layer')
 ch = logging.StreamHandler()
 ch.setLevel(logging.ERROR)
@@ -336,17 +338,17 @@ def test_suite():
     flags = (doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS)
 
     # Unit tests.
-    suite.addTest(unittest.makeSuite(CursorTest))
-    suite.addTest(unittest.makeSuite(HttpClientTest))
-    suite.addTest(unittest.makeSuite(KeepAliveClientTest))
-    suite.addTest(unittest.makeSuite(ThreadSafeHttpClientTest))
-    suite.addTest(unittest.makeSuite(ParamsTest))
-    suite.addTest(unittest.makeSuite(ConnectionTest))
-    suite.addTest(unittest.makeSuite(RetryOnTimeoutServerTest))
-    suite.addTest(unittest.makeSuite(RequestsCaBundleTest))
-    suite.addTest(unittest.makeSuite(TestUsernameSentAsHeader))
-    suite.addTest(unittest.makeSuite(TestCrateJsonEncoder))
-    suite.addTest(unittest.makeSuite(TestDefaultSchemaHeader))
+    suite.addTest(makeSuite(CursorTest))
+    suite.addTest(makeSuite(HttpClientTest))
+    suite.addTest(makeSuite(KeepAliveClientTest))
+    suite.addTest(makeSuite(ThreadSafeHttpClientTest))
+    suite.addTest(makeSuite(ParamsTest))
+    suite.addTest(makeSuite(ConnectionTest))
+    suite.addTest(makeSuite(RetryOnTimeoutServerTest))
+    suite.addTest(makeSuite(RequestsCaBundleTest))
+    suite.addTest(makeSuite(TestUsernameSentAsHeader))
+    suite.addTest(makeSuite(TestCrateJsonEncoder))
+    suite.addTest(makeSuite(TestDefaultSchemaHeader))
     suite.addTest(sqlalchemy_test_suite_unit())
     suite.addTest(doctest.DocTestSuite('crate.client.connection'))
     suite.addTest(doctest.DocTestSuite('crate.client.http'))

--- a/src/crate/testing/tests.py
+++ b/src/crate/testing/tests.py
@@ -24,8 +24,11 @@ import unittest
 from .test_layer import LayerUtilsTest, LayerTest
 
 
+makeSuite = unittest.TestLoader().loadTestsFromTestCase
+
+
 def test_suite():
     suite = unittest.TestSuite()
-    suite.addTest(unittest.makeSuite(LayerUtilsTest))
-    suite.addTest(unittest.makeSuite(LayerTest))
+    suite.addTest(makeSuite(LayerUtilsTest))
+    suite.addTest(makeSuite(LayerTest))
     return suite


### PR DESCRIPTION
## About

`unittest.makeSuite` is scheduled to be deprecated with Python 3.13, but already raises quite a number of warnings, obstructing the test suite output. This patch resolves that already.
