### PR TITLE
Documentation: Add link to "by-example" section to primary navigation

### DIFF
--- a/docs/by-example/index.rst
+++ b/docs/by-example/index.rst
@@ -4,13 +4,8 @@
 By example
 ##########
 
-
-*****
-About
-*****
-
-This part of the documentation contains examples how to use the CrateDB Python
-client.
+This part of the documentation enumerates different kinds of examples how to
+use the CrateDB Python client.
 
 
 DB API, HTTP, and BLOB interfaces

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -160,6 +160,11 @@ The DB API driver and the SQLAlchemy dialect support :ref:`CrateDB's data types
 please consult the :ref:`data-types` and :ref:`SQLAlchemy extension types
 <using-extension-types>` documentation pages.
 
+.. toctree::
+    :maxdepth: 2
+
+    data-types
+
 Examples
 ========
 
@@ -172,6 +177,11 @@ Examples
 - `Use CrateDB with pandas`_ has corresponding code snippets about how to
   connect to CrateDB using `pandas`_, and how to load and export data.
 - The `Apache Superset`_ and `FIWARE QuantumLeap data historian`_ projects.
+
+.. toctree::
+    :maxdepth: 2
+
+    by-example/index
 
 
 *******************

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,11 +36,9 @@ Documentation
 For general help about the Python Database API, or SQLAlchemy, please consult
 `PEP 249`_, the `SQLAlchemy tutorial`_, and the general `SQLAlchemy
 documentation`_.
-
 For more detailed information about how to install the client driver, how to
 connect to a CrateDB cluster, and how to run queries, consult the resources
-referenced below. A dedicated section demonstrates how to use the :ref:`blob
-storage capabilities <crate-reference:blob_support>` of CrateDB.
+referenced below.
 
 .. toctree::
     :titlesonly:


### PR DESCRIPTION
## About

There is no easy way to discover the ["By Example" section](https://crate.io/docs/python/en/latest/by-example/) of the documentation from the primary navigation.

![image](https://github.com/crate/crate-python/assets/453543/4f6cb6de-b42f-493a-9870-c55a8e011f3a)

This patch intends to add a corresponding item. While at it, it also adds a link to the "Data types" page.

![image](https://github.com/crate/crate-python/assets/453543/cc841bd9-c740-4b52-b81f-8455b83caf81)

Other than this, the patch improves the text layout/flow a bit, on two other spots.

## Preview

https://crate-python--574.org.readthedocs.build/en/574/
