### PR TITLE
SQLAlchemy: Improve DDL compiler to ignore unsupported features

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,7 +13,8 @@ Unreleased
   certificate details are immanent, like no longer accepting the long
   deprecated ``commonName`` attribute. Instead, going forward, only the
   ``subjectAltName`` attribute will be used.
-- SQLAlchemy: Improve DDL compiler to ignore foreign key constraints
+- SQLAlchemy: Improve DDL compiler to ignore foreign key and uniqueness
+  constraints
 
 .. _urllib3 v2.0 migration guide: https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html
 .. _urllib3 v2.0 roadmap: https://urllib3.readthedocs.io/en/stable/v2-roadmap.html

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -13,6 +13,7 @@ Unreleased
   certificate details are immanent, like no longer accepting the long
   deprecated ``commonName`` attribute. Instead, going forward, only the
   ``subjectAltName`` attribute will be used.
+- SQLAlchemy: Improve DDL compiler to ignore foreign key constraints
 
 .. _urllib3 v2.0 migration guide: https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html
 .. _urllib3 v2.0 roadmap: https://urllib3.readthedocs.io/en/stable/v2-roadmap.html

--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -178,6 +178,11 @@ class CrateDDLCompiler(compiler.DDLCompiler):
                 ', '.join(sorted(table_opts)))
         return special_options
 
+    def visit_foreign_key_constraint(self, constraint, **kw):
+        """
+        CrateDB does not support foreign key constraints.
+        """
+        return None
 
 class CrateTypeCompiler(compiler.GenericTypeCompiler):
 

--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -20,6 +20,7 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import string
+import warnings
 from collections import defaultdict
 
 import sqlalchemy as sa
@@ -182,12 +183,16 @@ class CrateDDLCompiler(compiler.DDLCompiler):
         """
         CrateDB does not support foreign key constraints.
         """
+        warnings.warn("CrateDB does not support foreign key constraints, "
+                      "they will be omitted when generating DDL statements.")
         return None
 
     def visit_unique_constraint(self, constraint, **kw):
         """
         CrateDB does not support unique key constraints.
         """
+        warnings.warn("CrateDB does not support unique constraints, "
+                      "they will be omitted when generating DDL statements.")
         return None
 
 

--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -184,6 +184,13 @@ class CrateDDLCompiler(compiler.DDLCompiler):
         """
         return None
 
+    def visit_unique_constraint(self, constraint, **kw):
+        """
+        CrateDB does not support unique key constraints.
+        """
+        return None
+
+
 class CrateTypeCompiler(compiler.GenericTypeCompiler):
 
     def visit_string(self, type_, **kw):

--- a/src/crate/client/sqlalchemy/tests/__init__.py
+++ b/src/crate/client/sqlalchemy/tests/__init__.py
@@ -14,7 +14,7 @@ from unittest import TestLoader, TestSuite
 from .connection_test import SqlAlchemyConnectionTest
 from .dict_test import SqlAlchemyDictTypeTest
 from .datetime_test import SqlAlchemyDateAndDateTimeTest
-from .compiler_test import SqlAlchemyCompilerTest
+from .compiler_test import SqlAlchemyCompilerTest, SqlAlchemyDDLCompilerTest
 from .update_test import SqlAlchemyUpdateTest
 from .match_test import SqlAlchemyMatchTest
 from .bulk_test import SqlAlchemyBulkTest
@@ -36,6 +36,7 @@ def test_suite_unit():
     tests.addTest(makeSuite(SqlAlchemyDictTypeTest))
     tests.addTest(makeSuite(SqlAlchemyDateAndDateTimeTest))
     tests.addTest(makeSuite(SqlAlchemyCompilerTest))
+    tests.addTest(makeSuite(SqlAlchemyDDLCompilerTest))
     tests.addTest(ParametrizedTestCase.parametrize(SqlAlchemyCompilerTest, param={"server_version_info": None}))
     tests.addTest(ParametrizedTestCase.parametrize(SqlAlchemyCompilerTest, param={"server_version_info": (4, 0, 12)}))
     tests.addTest(ParametrizedTestCase.parametrize(SqlAlchemyCompilerTest, param={"server_version_info": (4, 1, 10)}))


### PR DESCRIPTION
## About

Adjust SQLAlchemy's DDL compiler to ignore foreign key and uniqueness constraints, because CrateDB doesn't support them.

## Background

At recent work about unlocking MLflow and LangChain to work together with CrateDB [^1][^2], we needed to add some patches/workarounds.

Both of those to be integrated here are pretty straight-forward and non-invasive, and just mask corresponding SQL features not supported by CrateDB anyway, in order run applications with typical data schemas. Other dialects essentially to the same on their corresponding weak spots.

P.S.: I am intending to bring in this patch before running another release, where users are currently waiting for.

/cc @hlcianfagna, @hammerhead, @surister

[^1]: https://github.com/crate-workbench/mlflow-cratedb
[^2]: https://github.com/crate-workbench/langchain
