### PR TITLE
Improve exception handling: Properly raise `IntegrityError` exceptions

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,8 @@ Unreleased
   ``subjectAltName`` attribute will be used.
 - SQLAlchemy: Improve DDL compiler to ignore foreign key and uniqueness
   constraints
+- DBAPI: Properly raise ``IntegrityError`` exceptions instead of
+  ``ProgrammingError``, when CrateDB raises a ``DuplicateKeyException``.
 
 .. _urllib3 v2.0 migration guide: https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html
 .. _urllib3 v2.0 roadmap: https://urllib3.readthedocs.io/en/stable/v2-roadmap.html


### PR DESCRIPTION
## About

When receiving `DuplicateKeyException` errors from CrateDB, SQLAlchemy should raise corresponding `IntegrityError` exceptions instead of `ProgrammingError`, because applications expect it this way.

## Details

This patch evaluates the area preliminarily, mainly whether it will work by using CrateDB's own variants of the canonical DBAPI exceptions, and whether SQLAlchemy will honor that properly.

## References

- GH-578
