### PR TITLE
SQLAlchemy: Ignore SQL's "FOR UPDATE" clause

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,6 +17,7 @@ Unreleased
   constraints
 - DBAPI: Properly raise ``IntegrityError`` exceptions instead of
   ``ProgrammingError``, when CrateDB raises a ``DuplicateKeyException``.
+- SQLAlchemy: Ignore SQL's ``FOR UPDATE`` clause. Thanks, @surister.
 
 .. _urllib3 v2.0 migration guide: https://urllib3.readthedocs.io/en/latest/v2-migration-guide.html
 .. _urllib3 v2.0 roadmap: https://urllib3.readthedocs.io/en/stable/v2-roadmap.html

--- a/src/crate/client/sqlalchemy/compiler.py
+++ b/src/crate/client/sqlalchemy/compiler.py
@@ -309,3 +309,10 @@ class CrateCompiler(compiler.SQLCompiler):
         Generate OFFSET / LIMIT clause, PostgreSQL-compatible.
         """
         return PGCompiler.limit_clause(self, select, **kw)
+
+    def for_update_clause(self, select, **kw):
+        # CrateDB does not support the `INSERT ... FOR UPDATE` clause.
+        # See https://github.com/crate/crate-python/issues/577.
+        warnings.warn("CrateDB does not support the 'INSERT ... FOR UPDATE' clause, "
+                      "it will be omitted when generating SQL statements.")
+        return ''


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Pretty straightforward, now queries like `select(table).with_for_update()` will not generate a `FOR UPDATE` statement.

Resolves #577.
## Checklist

 - [x] Link to issue this PR refers to (if applicable): 
 - [x] [CLA](https://crate.io/community/contribute/cla/) is signed
