### PR TITLE
Documentation: Fix broken link to Python documentation

### DIFF
--- a/docs/data-types.rst
+++ b/docs/data-types.rst
@@ -47,7 +47,7 @@ CrateDB       Python
 ============= ===========
 
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#boolean
-__ https://docs.python.org/3/library/stdtypes.html#boolean-values
+__ https://docs.python.org/3/library/stdtypes.html#boolean-type-bool
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#character-data
 __ https://docs.python.org/3/library/stdtypes.html#str
 __ https://crate.io/docs/crate/reference/en/latest/general/ddl/data-types.html#numeric-data


### PR DESCRIPTION
## About

Nightly docs build tripped [^1], because Python changed an anchor reference on their documentation. This patch fixes the broken link.

[^1]: https://github.com/crate/crate-python/actions/runs/6415749066/job/17418188033#step:4:466
