### PR TITLE
Add support for Python 3.12

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.11'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'setup.py'
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         cratedb-version: ['nightly']
         sqla-version: ['latest']
         pip-allow-prerelease: ['false']

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -24,7 +24,7 @@ jobs:
         # Another CI test matrix slot to test against prerelease versions of Python packages.
         include:
           - os: 'ubuntu-latest'
-            python-version: '3.11'
+            python-version: '3.12'
             cratedb-version: 'nightly'
             sqla-version: 'latest'
             pip-allow-prerelease: 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           cache: 'pip'
           cache-dependency-path: 'setup.py'
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,8 +19,8 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11']
         cratedb-version: ['5.2.2']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
         sqla-version: ['<1.4', '<1.5', '<2.1']
         pip-allow-prerelease: ['false']
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         # Another CI test matrix slot to test against prerelease versions of Python packages.
         include:
           - os: 'ubuntu-latest'
-            python-version: '3.11'
+            python-version: '3.12'
             cratedb-version: '5.2.2'
             sqla-version: 'latest'
             pip-allow-prerelease: 'true'

--- a/setup.py
+++ b/setup.py
@@ -96,6 +96,7 @@ setup(
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Database'


### PR DESCRIPTION
## About

After https://github.com/jazzband/geojson/pull/222 has been released with geojson 3.1.0, verify that the package works well on Python 3.12, and announce it within the package's metadata. Also use it right away on other auxiliary CI tasks.
