### PR TITLE
CI: Use CrateDB 5.4.5

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
-        cratedb-version: ['5.2.2']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        cratedb-version: ['5.4.5']
         sqla-version: ['<1.4', '<1.5', '<2.1']
         pip-allow-prerelease: ['false']
 
-        # To save resources, only use the most recent Python version on macOS.
+        # To save resources, only use the most recent Python versions on macOS.
         exclude:
           - os: 'macos-latest'
             python-version: '3.7'
@@ -39,7 +39,7 @@ jobs:
         include:
           - os: 'ubuntu-latest'
             python-version: '3.12'
-            cratedb-version: '5.2.2'
+            cratedb-version: '5.4.5'
             sqla-version: 'latest'
             pip-allow-prerelease: 'true'
 


### PR DESCRIPTION
## About

On CI, use a more recent CrateDB version for the regular runs.

## NB
Download location is https://cdn.crate.io/downloads/releases/crate-5.4.4.tar.gz. Correct or outdated/legacy? /cc @seut 
