### PR TITLE
Sandbox: Download Linux variant of CrateDB from os/arch-specific URL

### DIFF
--- a/buildout.cfg
+++ b/buildout.cfg
@@ -6,7 +6,7 @@ parts = crate
 
 [crate:linux]
 recipe = hexagonit.recipe.download
-url = https://cdn.crate.io/downloads/releases/crate-${versions:crate_server}.tar.gz
+url = https://cdn.crate.io/downloads/releases/cratedb/x64_linux/crate-${versions:crate_server}.tar.gz
 strip-top-level-dir = true
 
 [crate:macosx]


### PR DESCRIPTION
## About

> Would be great if we could switch to using os/arch related download url's [^1] in future.
>
> -- https://github.com/crate/crate-python/pull/593#issuecomment-1794710816

[^1]: https://cdn.crate.io/downloads/releases/cratedb/x64_linux/


## References

- https://github.com/crate/crash/pull/406