### PR TITLE
CI: Fix running nightly jobs with CrateDB nightly

### DIFF
--- a/devtools/setup_ci.sh
+++ b/devtools/setup_ci.sh
@@ -12,7 +12,7 @@ function main() {
 
   # Replace CrateDB version.
   if [ ${CRATEDB_VERSION} = "nightly" ]; then
-    sed -ir "s/releases/releases\/nightly/g" buildout.cfg
+    sed -ir "s!releases/cratedb/x64_linux!releases/nightly!g" buildout.cfg
     sed -ir "s/crate_server.*/crate_server = latest/g" versions.cfg
   else
     sed -ir "s/crate_server.*/crate_server = ${CRATEDB_VERSION}/g" versions.cfg


### PR DESCRIPTION
## Problem

Apparently, GH-594 had a flaw when selecting CrateDB nightly, as we can see [on the nightly jobs](https://github.com/crate/crate-python/actions/workflows/nightly.yml), which probably started failing since this change.

## Solution

This patch adjusts the `sed` command correspondingly, so the nightly job will pick up the CrateDB nightly tarball for Linux again.