### PR TITLE
Types: Adjust CrateJsonEncoder to cast `Decimal` values to Python `float` types

### DIFF
--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -92,7 +92,9 @@ class CrateJsonEncoder(json.JSONEncoder):
     epoch_naive = datetime(1970, 1, 1)
 
     def default(self, o):
-        if isinstance(o, (Decimal, UUID)):
+        if isinstance(o, (Decimal,)):
+            return float(o)
+        if isinstance(o, (UUID,)):
             return str(o)
         if isinstance(o, datetime):
             if o.tzinfo is not None:


### PR DESCRIPTION
## About
This patch may be needed to fix value marshalling behaviour for `Decimal` types. It is apparently needed to be compatible with PostgreSQL.

This came up when using the SQLAlchemy dialect on behalf of a Singer/Meltano database sink component, in order to satisfy the software tests, where both implementation and test cases have been derived from the corresponding PostgreSQL adapter.

## Status
Not sure if it classifies as a bug, but indeed it feels like a bug if the driver deviates from the standard DBAPI/PostgreSQL behaviour. Based on further investigations, the patch needs to find the right slot in one way or another.

## References
- This is coming from a [monkeypatch to meltano-target-cratedb](https://github.com/crate-workbench/meltano-target-cratedb/blob/2b20640/target_cratedb/sqlalchemy/patch.py#L54-L68).
- It is related to https://github.com/crate-workbench/sqlalchemy-cratedb/pull/23 and https://github.com/crate-workbench/sqlalchemy-cratedb/pull/24.

## Backlog
- [ ] Adjust software tests.
- [ ] Just a short note about type support within the documentation.
- [ ] Changelog item. In this case, it is a **BREAKING CHANGE**, because, beforehand, values of `Decimal` type have been cast to Python's `str` type.
