### PR TITLE
Compatibility: Re-add `crate.client._pep440.Version` from `verlib2`

### DIFF
--- a/src/crate/client/_pep440.py
+++ b/src/crate/client/_pep440.py
@@ -1,0 +1,1 @@
+from verlib2 import Version  # noqa: F401


### PR DESCRIPTION
## About
This patch re-adds the `crate.client._pep440.Version` symbol, now from `verlib2.Version`, so that `crash` does not break.

## Problem
`crash` broke after releasing `crate==0.35.0`, so I've yanked it again.
```python
ModuleNotFoundError: No module named 'crate.client._pep440'
```
-- https://github.com/crate/crash/actions/runs/7562783871/job/20593938496?pr=421#step:5:29

## References
- https://github.com/crate/crash/pull/422
