### PR TITLE
CI: Fix CodeQL by installing Python

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,6 +36,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.11
+          architecture: x64
+          cache: 'pip'
+          cache-dependency-path: |
+            setup.py
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:


### PR DESCRIPTION
## Problem

That patch tripped CodeQL on CI.

- GH-608

## Root cause

Most probably this recent change by GitHub?

- https://github.blog/changelog/2024-01-23-codeql-2-16-python-dependency-installation-disabled-new-queries-and-bug-fixes/

## References

- https://github.com/crate-workbench/sqlalchemy-cratedb/pull/32
