### PR TITLE
CI: Update to GHA's codecov-action@v4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,6 +84,8 @@ jobs:
 
       # https://github.com/codecov/codecov-action
       - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           fail_ci_if_error: true


### PR DESCRIPTION
## About
After updating the ["secrets" on the GitHub project](https://github.com/crate/crate-python/settings/secrets/), this patch is the right solution, superseding GH-610.

## References
- https://github.com/panodata/aika/pull/55
- https://github.com/crate-workbench/mlflow-cratedb/pull/103
