### PR TITLE
Dependencies: Use `dask[dataframe]` for testing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(
               'zc.customdoctests>=1.0.1,<2',
               'certifi',
               'createcoverage>=1,<2',
-              'dask',
+              'dask[dataframe]',
               'stopit>=1.1.2,<2',
               'flake8>=4,<8',
               'pandas<2.3',


### PR DESCRIPTION
## Problem

```python
ImportError: Dask dataframe requirements are not installed.

Please either conda or pip install as follows:

  conda install dask                     # either conda install
  python -m pip install "dask[dataframe]" --upgrade  # or python -m pip install
```

-- https://github.com/crate/crate-python/actions/runs/8384462414/job/22961820586#step:4:702

## References
- https://github.com/daq-tools/influxio/pull/85
- https://github.com/crate-workbench/cratedb-toolkit/pull/128
- https://github.com/microsoft/LightGBM/issues/6365
- https://github.com/microsoft/LightGBM/pull/6357
