### PR TITLE
Disable leftover version chooser

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,6 +21,12 @@ intersphinx_mapping.update({
 linkcheck_anchors = True
 linkcheck_ignore = [r"https://github.com/crate/cratedb-examples/blob/main/by-language/python-sqlalchemy/.*"]
 
+# Disable version chooser.
+html_context.update({
+    "display_version": False,
+    "current_version": None,
+    "versions": [],
+})
 
 rst_prolog = """
 .. |nbsp| unicode:: 0xA0


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Since there are no versions of this docs repo, we might as well remove the version chooser to make space for headlines.