### PR TITLE
Chore: Fix software tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
+setuptools<70
 zc.buildout==3.0.1
+zope.interface==6.4


### PR DESCRIPTION
## About
Nightly test runs started failing 3 weeks ago, more specifically on Wed, 22 May 2024 2 o'clock AM GMT.
- https://github.com/crate/crate-python/actions/workflows/nightly.yml

## Problem
Test runs on Python 3.12 are tripped by this error, coming from zc.buildout.
```python
 Traceback (most recent call last):
  File "/path/to/.venv/bin/buildout", line 5, in <module>
    from zc.buildout.buildout import main
  File "/path/to/.venv/lib/python3.12/site-packages/zc/buildout/buildout.py", line 18, in <module>
    import zc.buildout.easy_install
  File "/path/to/.venv/lib/python3.12/site-packages/zc/buildout/easy_install.py", line 28, in <module>
    from pkg_resources import packaging
ImportError: cannot import name 'packaging' from 'pkg_resources'
```
- https://github.com/crate/crate-python/actions/runs/9184331584/job/25256465879#step:4:229

## Thoughts
How could it have worked before?
