### PR TITLE
Chore: Stop building universal wheels, being in Python 3 lands only

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[wheel]
-universal = 1
-
 [flake8]
 ignore = E501, C901, W503, W504


### PR DESCRIPTION
## Problem

The wheel file name of `crate` still indicates the package would be compatible with Python 2 [^1], which isn't the case. Other packages are doing it right [^2].

[^1]: https://pypi.org/project/crate/0.35.2/#files
[^2]: https://pypi.org/project/cratedb-toolkit/#files
