### PR TITLE
README: Refer to new SQLAlchemy dialect `sqlalchemy-cratedb`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@ CrateDB Python Client
     :target: https://pypi.org/project/crate/
     :alt: Python Version
 
-.. image:: https://img.shields.io/pypi/dw/crate.svg
-    :target: https://pypi.org/project/crate/
+.. image:: https://static.pepy.tech/badge/crate/month
+    :target: https://pepy.tech/project/crate
     :alt: PyPI Downloads
 
 .. image:: https://img.shields.io/pypi/wheel/crate.svg

--- a/README.rst
+++ b/README.rst
@@ -11,7 +11,7 @@ CrateDB Python Client
     :alt: Coverage
 
 .. image:: https://readthedocs.org/projects/crate-python/badge/
-    :target: https://crate.io/docs/python/
+    :target: https://cratedb.com/docs/python/
     :alt: Build status (documentation)
 
 .. image:: https://img.shields.io/pypi/v/crate.svg
@@ -77,9 +77,9 @@ GitHub`_. We appreciate contributions of any kind.
 
 .. _Contributing: CONTRIBUTING.rst
 .. _crate: https://pypi.org/project/crate/
-.. _Crate.io: https://crate.io/
+.. _Crate.io: https://cratedb.com/
 .. _CrateDB: https://github.com/crate/crate
-.. _CrateDB Python Client documentation: https://crate.io/docs/python/
+.. _CrateDB Python Client documentation: https://cratedb.com/docs/python/
 .. _CrateDB reference documentation: https://crate.io/docs/reference/
 .. _DB API 2.0: https://peps.python.org/pep-0249/
 .. _Developer documentation: DEVELOP.rst
@@ -89,4 +89,4 @@ GitHub`_. We appreciate contributions of any kind.
 .. _sqlalchemy-cratedb: https://github.com/crate/sqlalchemy-cratedb
 .. _sqlalchemy-cratedb documentation: https://cratedb.com/docs/sqlalchemy-cratedb/
 .. _StackOverflow: https://stackoverflow.com/tags/cratedb
-.. _support channels: https://crate.io/support/
+.. _support channels: https://cratedb.com/support/

--- a/README.rst
+++ b/README.rst
@@ -41,12 +41,11 @@ CrateDB Python Client
 
 |
 
-A Python client library for CrateDB_.
+A Python client library for `CrateDB`_, implementing the Python `DB API 2.0`_
+specification.
 
-This library:
-
-- Implements the Python `DB API 2.0`_ specification.
-- Includes support for SQLAlchemy_ in form of an `SQLAlchemy dialect`_.
+The CrateDB dialect for `SQLAlchemy`_ is provided by the `sqlalchemy-cratedb`_
+package, see also `sqlalchemy-cratedb documentation`_.
 
 
 Installation
@@ -54,10 +53,9 @@ Installation
 
 The CrateDB Python client is available as package `crate`_ on `PyPI`_.
 
-To install the most recent driver version, including the SQLAlchemy dialect
-extension, run::
+To install the most recent driver version, run::
 
-    $ pip install "crate[sqlalchemy]" --upgrade
+    $ pip install --upgrade crate
 
 
 Documentation and help
@@ -87,7 +85,8 @@ GitHub`_. We appreciate contributions of any kind.
 .. _Developer documentation: DEVELOP.rst
 .. _managed on GitHub: https://github.com/crate/crate-python
 .. _PyPI: https://pypi.org/
-.. _SQLAlchemy: https://www.sqlalchemy.org
-.. _SQLAlchemy dialect: https://docs.sqlalchemy.org/dialects/
+.. _SQLAlchemy: https://www.sqlalchemy.org/
+.. _sqlalchemy-cratedb: https://github.com/crate/sqlalchemy-cratedb
+.. _sqlalchemy-cratedb documentation: https://cratedb.com/docs/sqlalchemy-cratedb/
 .. _StackOverflow: https://stackoverflow.com/tags/cratedb
 .. _support channels: https://crate.io/support/


### PR DESCRIPTION
## About
A little documentation patch to prepare GH-616.

## References
- https://github.com/crate/crate-python/issues/620