### PR TITLE
CI: Use CrateDB `nightly` also for regular testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-        cratedb-version: ['5.7.2']
+        cratedb-version: ['nightly']
 
         # To save resources, only use the most recent Python versions on macOS.
         exclude:


### PR DESCRIPTION
## About
CrateDB version was fixed to 5.4.5. This patch intends to use ~~`latest`~~ `nightly`.

## Thoughts
`latest` will probably not work, because the test layer used here only understands specific version numbers, and `nightly`?