### PR TITLE
CI: Update from CrateDB 5.4.5 to 5.7.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-        cratedb-version: ['5.4.5']
+        cratedb-version: ['5.7.2']
 
         # To save resources, only use the most recent Python versions on macOS.
         exclude:


### PR DESCRIPTION
## About
What the title says.

## Trivia
Unfortunately, we currently can't use "latest" or "nightly" here, because of the venerable x64_mac build matrix anomaly of CrateDB.
- GH-624
