### PR TITLE
Configure DB API interface attribute `threadsafety = 1`: Threads may share the module, but not connections

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,6 +8,8 @@ Unreleased
 - The SQLAlchemy dialect has been split off into the `sqlalchemy-cratedb`_
   package. See `Migrate from crate.client to sqlalchemy-cratedb`_ to learn
   about necessary migration steps.
+- Configured DB API interface attribute ``threadsafety = 1``, which signals
+  "Threads may share the module, but not connections."
 
 .. _Migrate from crate.client to sqlalchemy-cratedb: https://cratedb.com/docs/sqlalchemy-cratedb/migrate-from-crate-client.html
 .. _sqlalchemy-cratedb: https://pypi.org/project/sqlalchemy-cratedb/

--- a/src/crate/client/__init__.py
+++ b/src/crate/client/__init__.py
@@ -32,5 +32,5 @@ __all__ = [
 __version__ = "0.35.2"
 
 apilevel = "2.0"
-threadsafety = 2
+threadsafety = 1
 paramstyle = "qmark"


### PR DESCRIPTION
## About
Relating to the [section about thread safety in PEP 0249](https://peps.python.org/pep-0249/#threadsafety) ...

- The driver currently configures `threadsafety = 2`, which means "Threads may share the module and connections."
- Now, it will configure `threadsafety = 1`, which means "Threads may share the module, but not connections."

## Discussion

@hlcianfagna asked:

> When using the python driver, is it ok to share a connection with multiple threads each opening their own cursor or should each thread have its own connection?

@amotl said:

> Thread-per-connection sounds reasonable.

@mfussenegger said:

> I think it currently relies on Python GIL, and afaik if you'd share a connection with the `multiprocessing` module across processes, things would break. So, it could be worth changing that to 1.

@hlcianfagna said:

> I would say the same, should we document it?

## References
- [Python Driver: Using multiple cursors parallel](https://community.cratedb.com/t/python-crate-using-multiple-cursors-parallel/1788)

/cc @hlcianfagna, @hammerhead, @surister, @proddata, @simonprickett 