### PR TITLE
Add `error_trace` to string representation of an Error

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,6 +10,8 @@ Unreleased
   about necessary migration steps.
 - Configured DB API interface attribute ``threadsafety = 1``, which signals
   "Threads may share the module, but not connections."
+- Added ``error_trace`` to string representation of an Error to relay
+  server stacktraces into exception messages.
 
 .. _Migrate from crate.client to sqlalchemy-cratedb: https://cratedb.com/docs/sqlalchemy-cratedb/migrate-from-crate-client.html
 .. _sqlalchemy-cratedb: https://pypi.org/project/sqlalchemy-cratedb/

--- a/src/crate/client/exceptions.py
+++ b/src/crate/client/exceptions.py
@@ -30,6 +30,11 @@ class Error(Exception):
         super(Error, self).__init__(msg)
         self.error_trace = error_trace
 
+    def __str__(self):
+        if self.error_trace is None:
+            return super().__str__()
+        return "\n".join([super().__str__(), str(self.error_trace)])
+
 
 class Warning(Exception):
     pass

--- a/src/crate/client/test_exceptions.py
+++ b/src/crate/client/test_exceptions.py
@@ -1,0 +1,14 @@
+import unittest
+
+from crate.client import Error
+
+
+class ErrorTestCase(unittest.TestCase):
+
+    def test_error_with_msg(self):
+        err = Error("foo")
+        self.assertEqual(str(err), "foo")
+
+    def test_error_with_error_trace(self):
+        err = Error("foo", error_trace="### TRACE ###")
+        self.assertEqual(str(err), "foo\n### TRACE ###")


### PR DESCRIPTION
If the `error_trace` payload is available, add it to the string representation of the Error class.

This way, any layer using the driver, e.g. our SqlAlchemy Dialect, can display the error trace without to handle concrete exceptions. Additionally, handling the concrete exception and reading the `self.error_trace` variable won't be always possible (e.g. in generic SqlAlchemy abstractions).
If the error_trace is available is already depending on the concrete `connect(error_trace=True)` attribute and thus in control of the user.