### PR TITLE
Sandbox: Don't limit setuptools version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
-setuptools<70
 zc.buildout==3.1.0
 zope.interface==6.4.post2


### PR DESCRIPTION
## About
Roll back a temporary version pinning on the `setuptools` package.

## References
- https://github.com/crate/crate-python/pull/617
- GH-645
- https://github.com/crate/crate-python/security/dependabot/1
