### PR TITLE
Chore: Use CrateDB 5.8.3 for testing

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       matrix:
         os: ['ubuntu-latest', 'macos-latest']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
-        cratedb-version: ['5.7.2']
+        cratedb-version: ['5.8.3']
 
         # To save resources, only use the most recent Python versions on macOS.
         exclude:

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -17,7 +17,7 @@
 # set -x
 
 # Default variables.
-CRATEDB_VERSION=${CRATEDB_VERSION:-5.2.2}
+CRATEDB_VERSION=${CRATEDB_VERSION:-5.8.3}
 
 
 function print_header() {


### PR DESCRIPTION
## About
Maintenance: Just update CrateDB to use the most recent version.

## Details
Unfortunately, the test suite currently can't use neither of "latest", nor "testing".

## References
- GH-624