### PR TITLE
Documentation: Update to crate-docs-theme 0.35.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-crate-docs-theme
+crate-docs-theme==0.35.0.dev3


### PR DESCRIPTION
## About
This compensates for upstream changes introduced by Read The Docs.

> [...] introduction of [Read the Docs Addons](https://about.readthedocs.com/blog/2024/04/enable-beta-addons/) to **all the projects by default starting on October 7, 2024**.
>
> --https://about.readthedocs.com/blog/2024/07/addons-by-default/

## Preview
- https://crate-python--654.org.readthedocs.build/en/654/

## References
- https://github.com/crate/crate-docs-theme/issues/536
