### PR TITLE
QA and CI: Format code using ruff. Validate using ruff and mypy.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,7 +63,7 @@ jobs:
           echo "Invoking tests with CrateDB ${CRATEDB_VERSION}"
 
           # Run linter.
-          flake8 src bin
+          poe lint
           
           # Run tests.
           coverage run bin/test -vvv

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -32,7 +32,7 @@ see, for example, `useful command-line options for zope-testrunner`_.
 
 Run all tests::
 
-    bin/test
+    poe test
 
 Run specific tests::
 
@@ -81,6 +81,23 @@ To run against a single interpreter, you can also invoke::
 *Note*: Before running the tests, make sure to stop all CrateDB instances which
 are listening on the default CrateDB transport port to avoid side effects with
 the test layer.
+
+
+Formatting and linting code
+===========================
+
+To use Ruff for code formatting, according to the standards configured in
+``pyproject.toml``, use::
+
+    poe format
+
+To lint the code base using Ruff and mypy, use::
+
+    poe lint
+
+Linting and software testing, all together now::
+
+    poe check
 
 
 Renew certificates

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -110,7 +110,7 @@ function main() {
 }
 
 function lint() {
-    flake8 "$@" src bin
+    poe lint
 }
 
 main

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
+# ruff: noqa: F403, F405
 from crate.theme.rtd.conf.python import *
-
 
 if "sphinx.ext.intersphinx" not in extensions:
     extensions += ["sphinx.ext.intersphinx"]
@@ -9,21 +9,25 @@ if "intersphinx_mapping" not in globals():
     intersphinx_mapping = {}
 
 
-intersphinx_mapping.update({
-    'py': ('https://docs.python.org/3/', None),
-    'urllib3': ('https://urllib3.readthedocs.io/en/1.26.13/', None),
-    })
+intersphinx_mapping.update(
+    {
+        "py": ("https://docs.python.org/3/", None),
+        "urllib3": ("https://urllib3.readthedocs.io/en/1.26.13/", None),
+    }
+)
 
 
 linkcheck_anchors = True
 linkcheck_ignore = []
 
 # Disable version chooser.
-html_context.update({
-    "display_version": False,
-    "current_version": None,
-    "versions": [],
-})
+html_context.update(
+    {
+        "display_version": False,
+        "current_version": None,
+        "versions": [],
+    }
+)
 
 rst_prolog = """
 .. |nbsp| unicode:: 0xA0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,102 @@
 [tool.mypy]
+mypy_path = "src"
+packages = [
+  "crate",
+]
+exclude = [
+]
+check_untyped_defs = true
+explicit_package_bases = true
+ignore_missing_imports = true
+implicit_optional = true
+install_types = true
+namespace_packages = true
+non_interactive = true
 
-# Needed until `mypy-0.990` for `ConverterDefinition` in `converter.py`.
-# https://github.com/python/mypy/issues/731#issuecomment-1260976955
-enable_recursive_aliases = true
+
+[tool.ruff]
+line-length = 80
+
+extend-exclude = [
+  "/example_*",
+]
+
+lint.select = [
+  # Builtins
+  "A",
+  # Bugbear
+  "B",
+  # comprehensions
+  "C4",
+  # Pycodestyle
+  "E",
+  # eradicate
+  "ERA",
+  # Pyflakes
+  "F",
+  # isort
+  "I",
+  # pandas-vet
+  "PD",
+  # return
+  "RET",
+  # Bandit
+  "S",
+  # print
+  "T20",
+  "W",
+  # flake8-2020
+  "YTT",
+]
+
+lint.extend-ignore = [
+  # Unnecessary variable assignment before `return` statement
+  "RET504",
+  # Unnecessary `elif` after `return` statement
+  "RET505",
+]
+
+lint.per-file-ignores."example_*" = [
+  "ERA001", # Found commented-out code
+  "T201",   # Allow `print`
+]
+lint.per-file-ignores."devtools/*" = [
+  "T201",   # Allow `print`
+]
+lint.per-file-ignores."examples/*" = [
+  "ERA001", # Found commented-out code
+  "T201",   # Allow `print`
+]
+lint.per-file-ignores."tests/*" = [
+  "S106",  # Possible hardcoded password assigned to argument: "password"
+  "S311",  # Standard pseudo-random generators are not suitable for cryptographic purposes
+]
+
+
+# ===================
+# Tasks configuration
+# ===================
+
+[tool.poe.tasks]
+
+check = [
+  "lint",
+  "test",
+]
+
+format = [
+  { cmd = "ruff format ." },
+  # Configure Ruff not to auto-fix (remove!):
+  # unused imports (F401), unused variables (F841), `print` statements (T201), and commented-out code (ERA001).
+  { cmd = "ruff check --fix --ignore=ERA --ignore=F401 --ignore=F841 --ignore=T20 --ignore=ERA001 ." },
+]
+
+lint = [
+  { cmd = "ruff format --check ." },
+  { cmd = "ruff check ." },
+  { cmd = "mypy" },
+]
+
+test = [
+  { cmd = "bin/test" },
+]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[flake8]
-ignore = E501, C901, W503, W504

--- a/setup.py
+++ b/setup.py
@@ -19,9 +19,10 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-from setuptools import setup, find_packages
 import os
 import re
+
+from setuptools import find_packages, setup
 
 
 def read(path):
@@ -29,68 +30,73 @@ def read(path):
         return f.read()
 
 
-long_description = read('README.rst')
+long_description = read("README.rst")
 versionf_content = read("src/crate/client/__init__.py")
 version_rex = r'^__version__ = [\'"]([^\'"]*)[\'"]$'
 m = re.search(version_rex, versionf_content, re.M)
 if m:
     version = m.group(1)
 else:
-    raise RuntimeError('Unable to find version string')
+    raise RuntimeError("Unable to find version string")
 
 setup(
-    name='crate',
+    name="crate",
     version=version,
-    url='https://github.com/crate/crate-python',
-    author='Crate.io',
-    author_email='office@crate.io',
-    package_dir={'': 'src'},
-    description='CrateDB Python Client',
+    url="https://github.com/crate/crate-python",
+    author="Crate.io",
+    author_email="office@crate.io",
+    package_dir={"": "src"},
+    description="CrateDB Python Client",
     long_description=long_description,
-    long_description_content_type='text/x-rst',
-    platforms=['any'],
-    license='Apache License 2.0',
-    keywords='cratedb db api dbapi database sql http rdbms olap',
-    packages=find_packages('src'),
-    namespace_packages=['crate'],
+    long_description_content_type="text/x-rst",
+    platforms=["any"],
+    license="Apache License 2.0",
+    keywords="cratedb db api dbapi database sql http rdbms olap",
+    packages=find_packages("src"),
+    namespace_packages=["crate"],
     install_requires=[
-        'urllib3<2.3',
-        'verlib2==0.2.0',
+        "urllib3<2.3",
+        "verlib2==0.2.0",
     ],
-    extras_require=dict(
-        test=['tox>=3,<5',
-              'zope.testing>=4,<6',
-              'zope.testrunner>=5,<7',
-              'zc.customdoctests>=1.0.1,<2',
-              'backports.zoneinfo<1; python_version<"3.9"',
-              'certifi',
-              'createcoverage>=1,<2',
-              'stopit>=1.1.2,<2',
-              'flake8>=4,<8',
-              'pytz',
-              ],
-        doc=['sphinx>=3.5,<9',
-             'crate-docs-theme>=0.26.5'],
-    ),
-    python_requires='>=3.6',
-    package_data={'': ['*.txt']},
+    extras_require={
+        "doc": [
+            "crate-docs-theme>=0.26.5",
+            "sphinx>=3.5,<9",
+        ],
+        "test": [
+            'backports.zoneinfo<1; python_version<"3.9"',
+            "certifi",
+            "createcoverage>=1,<2",
+            "mypy<1.14",
+            "poethepoet<0.30",
+            "ruff<0.8",
+            "stopit>=1.1.2,<2",
+            "tox>=3,<5",
+            "pytz",
+            "zc.customdoctests>=1.0.1,<2",
+            "zope.testing>=4,<6",
+            "zope.testrunner>=5,<7",
+        ],
+    },
+    python_requires=">=3.6",
+    package_data={"": ["*.txt"]},
     classifiers=[
-        'Development Status :: 5 - Production/Stable',
-        'Intended Audience :: Developers',
-        'License :: OSI Approved :: Apache Software License',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python',
-        'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10',
-        'Programming Language :: Python :: 3.11',
-        'Programming Language :: Python :: 3.12',
-        'Programming Language :: Python :: 3.13',
-        'Programming Language :: Python :: Implementation :: CPython',
-        'Programming Language :: Python :: Implementation :: PyPy',
-        'Topic :: Database'
+        "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: Apache Software License",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: Implementation :: CPython",
+        "Programming Language :: Python :: Implementation :: PyPy",
+        "Topic :: Database",
     ],
 )

--- a/src/crate/__init__.py
+++ b/src/crate/__init__.py
@@ -22,7 +22,9 @@
 # this is a namespace package
 try:
     import pkg_resources
+
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
+
     __path__ = pkgutil.extend_path(__path__, __name__)

--- a/src/crate/client/__init__.py
+++ b/src/crate/client/__init__.py
@@ -23,8 +23,8 @@ from .connection import Connection as connect
 from .exceptions import Error
 
 __all__ = [
-    connect,
-    Error,
+    "connect",
+    "Error",
 ]
 
 # version string read from setup.py using a regex. Take care not to break the

--- a/src/crate/client/blob.py
+++ b/src/crate/client/blob.py
@@ -22,8 +22,8 @@
 import hashlib
 
 
-class BlobContainer(object):
-    """ class that represents a blob collection in crate.
+class BlobContainer:
+    """class that represents a blob collection in crate.
 
     can be used to download, upload and delete blobs
     """
@@ -34,7 +34,7 @@ class BlobContainer(object):
 
     def _compute_digest(self, f):
         f.seek(0)
-        m = hashlib.sha1()
+        m = hashlib.sha1()  # noqa: S324
         while True:
             d = f.read(1024 * 32)
             if not d:
@@ -64,8 +64,9 @@ class BlobContainer(object):
         else:
             actual_digest = self._compute_digest(f)
 
-        created = self.conn.client.blob_put(self.container_name,
-                                            actual_digest, f)
+        created = self.conn.client.blob_put(
+            self.container_name, actual_digest, f
+        )
         if digest:
             return created
         return actual_digest
@@ -78,8 +79,9 @@ class BlobContainer(object):
         :param chunk_size: the size of the chunks returned on each iteration
         :return: generator returning chunks of data
         """
-        return self.conn.client.blob_get(self.container_name, digest,
-                                         chunk_size)
+        return self.conn.client.blob_get(
+            self.container_name, digest, chunk_size
+        )
 
     def delete(self, digest):
         """

--- a/src/crate/client/connection.py
+++ b/src/crate/client/connection.py
@@ -19,37 +19,38 @@
 # with Crate these terms will supersede the license and you may use the
 # software solely pursuant to the terms of the relevant commercial agreement.
 
-from .cursor import Cursor
-from .exceptions import ProgrammingError, ConnectionError
-from .http import Client
-from .blob import BlobContainer
 from verlib2 import Version
 
+from .blob import BlobContainer
+from .cursor import Cursor
+from .exceptions import ConnectionError, ProgrammingError
+from .http import Client
 
-class Connection(object):
 
-    def __init__(self,
-                 servers=None,
-                 timeout=None,
-                 backoff_factor=0,
-                 client=None,
-                 verify_ssl_cert=True,
-                 ca_cert=None,
-                 error_trace=False,
-                 cert_file=None,
-                 key_file=None,
-                 ssl_relax_minimum_version=False,
-                 username=None,
-                 password=None,
-                 schema=None,
-                 pool_size=None,
-                 socket_keepalive=True,
-                 socket_tcp_keepidle=None,
-                 socket_tcp_keepintvl=None,
-                 socket_tcp_keepcnt=None,
-                 converter=None,
-                 time_zone=None,
-                 ):
+class Connection:
+    def __init__(
+        self,
+        servers=None,
+        timeout=None,
+        backoff_factor=0,
+        client=None,
+        verify_ssl_cert=True,
+        ca_cert=None,
+        error_trace=False,
+        cert_file=None,
+        key_file=None,
+        ssl_relax_minimum_version=False,
+        username=None,
+        password=None,
+        schema=None,
+        pool_size=None,
+        socket_keepalive=True,
+        socket_tcp_keepidle=None,
+        socket_tcp_keepintvl=None,
+        socket_tcp_keepcnt=None,
+        converter=None,
+        time_zone=None,
+    ):
         """
         :param servers:
             either a string in the form of '<hostname>:<port>'
@@ -123,7 +124,7 @@ class Connection(object):
 
             When `time_zone` is given, the returned `datetime` objects are "aware",
             with `tzinfo` set, converted using ``datetime.fromtimestamp(..., tz=...)``.
-        """
+        """  # noqa: E501
 
         self._converter = converter
         self.time_zone = time_zone
@@ -131,24 +132,25 @@ class Connection(object):
         if client:
             self.client = client
         else:
-            self.client = Client(servers,
-                                 timeout=timeout,
-                                 backoff_factor=backoff_factor,
-                                 verify_ssl_cert=verify_ssl_cert,
-                                 ca_cert=ca_cert,
-                                 error_trace=error_trace,
-                                 cert_file=cert_file,
-                                 key_file=key_file,
-                                 ssl_relax_minimum_version=ssl_relax_minimum_version,
-                                 username=username,
-                                 password=password,
-                                 schema=schema,
-                                 pool_size=pool_size,
-                                 socket_keepalive=socket_keepalive,
-                                 socket_tcp_keepidle=socket_tcp_keepidle,
-                                 socket_tcp_keepintvl=socket_tcp_keepintvl,
-                                 socket_tcp_keepcnt=socket_tcp_keepcnt,
-                                 )
+            self.client = Client(
+                servers,
+                timeout=timeout,
+                backoff_factor=backoff_factor,
+                verify_ssl_cert=verify_ssl_cert,
+                ca_cert=ca_cert,
+                error_trace=error_trace,
+                cert_file=cert_file,
+                key_file=key_file,
+                ssl_relax_minimum_version=ssl_relax_minimum_version,
+                username=username,
+                password=password,
+                schema=schema,
+                pool_size=pool_size,
+                socket_keepalive=socket_keepalive,
+                socket_tcp_keepidle=socket_tcp_keepidle,
+                socket_tcp_keepintvl=socket_tcp_keepintvl,
+                socket_tcp_keepcnt=socket_tcp_keepcnt,
+            )
         self.lowest_server_version = self._lowest_server_version()
         self._closed = False
 
@@ -182,7 +184,7 @@ class Connection(object):
             raise ProgrammingError("Connection closed")
 
     def get_blob_container(self, container_name):
-        """ Retrieve a BlobContainer for `container_name`
+        """Retrieve a BlobContainer for `container_name`
 
         :param container_name: the name of the BLOB container.
         :returns: a :class:ContainerObject
@@ -199,10 +201,10 @@ class Connection(object):
                 continue
             if not lowest or version < lowest:
                 lowest = version
-        return lowest or Version('0.0.0')
+        return lowest or Version("0.0.0")
 
     def __repr__(self):
-        return '<Connection {0}>'.format(repr(self.client))
+        return "<Connection {0}>".format(repr(self.client))
 
     def __enter__(self):
         return self

--- a/src/crate/client/converter.py
+++ b/src/crate/client/converter.py
@@ -23,6 +23,7 @@ Machinery for converting CrateDB database types to native Python data types.
 
 https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#column-types
 """
+
 import ipaddress
 from copy import deepcopy
 from datetime import datetime
@@ -33,7 +34,9 @@ ConverterFunction = Callable[[Optional[Any]], Optional[Any]]
 ColTypesDefinition = Union[int, List[Union[int, "ColTypesDefinition"]]]
 
 
-def _to_ipaddress(value: Optional[str]) -> Optional[Union[ipaddress.IPv4Address, ipaddress.IPv6Address]]:
+def _to_ipaddress(
+    value: Optional[str],
+) -> Optional[Union[ipaddress.IPv4Address, ipaddress.IPv6Address]]:
     """
     https://docs.python.org/3/library/ipaddress.html
     """
@@ -55,7 +58,7 @@ def _to_default(value: Optional[Any]) -> Optional[Any]:
     return value
 
 
-# Symbolic aliases for the numeric data type identifiers defined by the CrateDB HTTP interface.
+# Data type identifiers defined by the CrateDB HTTP interface.
 # https://crate.io/docs/crate/reference/en/latest/interfaces/http.html#column-types
 class DataType(Enum):
     NULL = 0
@@ -112,7 +115,9 @@ class Converter:
             return self._mappings.get(DataType(type_), self._default)
         type_, inner_type = type_
         if DataType(type_) is not DataType.ARRAY:
-            raise ValueError(f"Data type {type_} is not implemented as collection type")
+            raise ValueError(
+                f"Data type {type_} is not implemented as collection type"
+            )
 
         inner_convert = self.get(inner_type)
 
@@ -128,11 +133,11 @@ class Converter:
 
 
 class DefaultTypeConverter(Converter):
-    def __init__(self, more_mappings: Optional[ConverterMapping] = None) -> None:
+    def __init__(
+        self, more_mappings: Optional[ConverterMapping] = None
+    ) -> None:
         mappings: ConverterMapping = {}
         mappings.update(deepcopy(_DEFAULT_CONVERTERS))
         if more_mappings:
             mappings.update(deepcopy(more_mappings))
-        super().__init__(
-            mappings=mappings, default=_to_default
-        )
+        super().__init__(mappings=mappings, default=_to_default)

--- a/src/crate/client/exceptions.py
+++ b/src/crate/client/exceptions.py
@@ -21,7 +21,6 @@
 
 
 class Error(Exception):
-
     def __init__(self, msg=None, error_trace=None):
         # for compatibility reasons we want to keep the exception message
         # attribute because clients may depend on it
@@ -36,7 +35,8 @@ class Error(Exception):
         return "\n".join([super().__str__(), str(self.error_trace)])
 
 
-class Warning(Exception):
+# A001 Variable `Warning` is shadowing a Python builtin
+class Warning(Exception):  # noqa: A001
     pass
 
 
@@ -74,7 +74,9 @@ class NotSupportedError(DatabaseError):
 
 # exceptions not in db api
 
-class ConnectionError(OperationalError):
+
+# A001 Variable `ConnectionError` is shadowing a Python builtin
+class ConnectionError(OperationalError):  # noqa: A001
     pass
 
 

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -30,11 +30,11 @@ import re
 import socket
 import ssl
 import threading
-from urllib.parse import urlparse
 from base64 import b64encode
-from time import time
-from datetime import datetime, date, timezone
+from datetime import date, datetime, timezone
 from decimal import Decimal
+from time import time
+from urllib.parse import urlparse
 from uuid import UUID
 
 import urllib3
@@ -52,42 +52,41 @@ from urllib3.util.retry import Retry
 from verlib2 import Version
 
 from crate.client.exceptions import (
-    ConnectionError,
     BlobLocationNotFoundException,
+    ConnectionError,
     DigestNotFoundException,
-    ProgrammingError,
     IntegrityError,
+    ProgrammingError,
 )
-
 
 logger = logging.getLogger(__name__)
 
 
-_HTTP_PAT = pat = re.compile('https?://.+', re.I)
-SRV_UNAVAILABLE_STATUSES = set((502, 503, 504, 509))
-PRESERVE_ACTIVE_SERVER_EXCEPTIONS = set((ConnectionResetError, BrokenPipeError))
-SSL_ONLY_ARGS = set(('ca_certs', 'cert_reqs', 'cert_file', 'key_file'))
+_HTTP_PAT = pat = re.compile("https?://.+", re.I)
+SRV_UNAVAILABLE_STATUSES = {502, 503, 504, 509}
+PRESERVE_ACTIVE_SERVER_EXCEPTIONS = {ConnectionResetError, BrokenPipeError}
+SSL_ONLY_ARGS = {"ca_certs", "cert_reqs", "cert_file", "key_file"}
 
 
 def super_len(o):
-    if hasattr(o, '__len__'):
+    if hasattr(o, "__len__"):
         return len(o)
-    if hasattr(o, 'len'):
+    if hasattr(o, "len"):
         return o.len
-    if hasattr(o, 'fileno'):
+    if hasattr(o, "fileno"):
         try:
             fileno = o.fileno()
         except io.UnsupportedOperation:
             pass
         else:
             return os.fstat(fileno).st_size
-    if hasattr(o, 'getvalue'):
+    if hasattr(o, "getvalue"):
         # e.g. BytesIO, cStringIO.StringI
         return len(o.getvalue())
+    return None
 
 
 class CrateJsonEncoder(json.JSONEncoder):
-
     epoch_aware = datetime(1970, 1, 1, tzinfo=timezone.utc)
     epoch_naive = datetime(1970, 1, 1)
 
@@ -99,21 +98,22 @@ class CrateJsonEncoder(json.JSONEncoder):
                 delta = o - self.epoch_aware
             else:
                 delta = o - self.epoch_naive
-            return int(delta.microseconds / 1000.0 +
-                       (delta.seconds + delta.days * 24 * 3600) * 1000.0)
+            return int(
+                delta.microseconds / 1000.0
+                + (delta.seconds + delta.days * 24 * 3600) * 1000.0
+            )
         if isinstance(o, date):
             return calendar.timegm(o.timetuple()) * 1000
         return json.JSONEncoder.default(self, o)
 
 
-class Server(object):
-
+class Server:
     def __init__(self, server, **pool_kw):
         socket_options = _get_socket_opts(
-            pool_kw.pop('socket_keepalive', False),
-            pool_kw.pop('socket_tcp_keepidle', None),
-            pool_kw.pop('socket_tcp_keepintvl', None),
-            pool_kw.pop('socket_tcp_keepcnt', None),
+            pool_kw.pop("socket_keepalive", False),
+            pool_kw.pop("socket_tcp_keepidle", None),
+            pool_kw.pop("socket_tcp_keepintvl", None),
+            pool_kw.pop("socket_tcp_keepcnt", None),
         )
         self.pool = connection_from_url(
             server,
@@ -121,53 +121,57 @@ class Server(object):
             **pool_kw,
         )
 
-    def request(self,
-                method,
-                path,
-                data=None,
-                stream=False,
-                headers=None,
-                username=None,
-                password=None,
-                schema=None,
-                backoff_factor=0,
-                **kwargs):
+    def request(
+        self,
+        method,
+        path,
+        data=None,
+        stream=False,
+        headers=None,
+        username=None,
+        password=None,
+        schema=None,
+        backoff_factor=0,
+        **kwargs,
+    ):
         """Send a request
 
         Always set the Content-Length and the Content-Type header.
         """
         if headers is None:
             headers = {}
-        if 'Content-Length' not in headers:
+        if "Content-Length" not in headers:
             length = super_len(data)
             if length is not None:
-                headers['Content-Length'] = length
+                headers["Content-Length"] = length
 
         # Authentication credentials
         if username is not None:
-            if 'Authorization' not in headers and username is not None:
-                credentials = username + ':'
+            if "Authorization" not in headers and username is not None:
+                credentials = username + ":"
                 if password is not None:
                     credentials += password
-                headers['Authorization'] = 'Basic %s' % b64encode(credentials.encode('utf-8')).decode('utf-8')
+                headers["Authorization"] = "Basic %s" % b64encode(
+                    credentials.encode("utf-8")
+                ).decode("utf-8")
             # For backwards compatibility with Crate <= 2.2
-            if 'X-User' not in headers:
-                headers['X-User'] = username
+            if "X-User" not in headers:
+                headers["X-User"] = username
 
         if schema is not None:
-            headers['Default-Schema'] = schema
-        headers['Accept'] = 'application/json'
-        headers['Content-Type'] = 'application/json'
-        kwargs['assert_same_host'] = False
-        kwargs['redirect'] = False
-        kwargs['retries'] = Retry(read=0, backoff_factor=backoff_factor)
+            headers["Default-Schema"] = schema
+        headers["Accept"] = "application/json"
+        headers["Content-Type"] = "application/json"
+        kwargs["assert_same_host"] = False
+        kwargs["redirect"] = False
+        kwargs["retries"] = Retry(read=0, backoff_factor=backoff_factor)
         return self.pool.urlopen(
             method,
             path,
             body=data,
             preload_content=not stream,
             headers=headers,
-            **kwargs
+            **kwargs,
         )
 
     def close(self):
@@ -176,24 +180,27 @@ class Server(object):
 
 def _json_from_response(response):
     try:
-        return json.loads(response.data.decode('utf-8'))
-    except ValueError:
+        return json.loads(response.data.decode("utf-8"))
+    except ValueError as ex:
         raise ProgrammingError(
-            "Invalid server response of content-type '{}':\n{}"
-            .format(response.headers.get("content-type", "unknown"), response.data.decode('utf-8')))
+            "Invalid server response of content-type '{}':\n{}".format(
+                response.headers.get("content-type", "unknown"),
+                response.data.decode("utf-8"),
+            )
+        ) from ex
 
 
 def _blob_path(table, digest):
-    return '/_blobs/{table}/{digest}'.format(table=table, digest=digest)
+    return "/_blobs/{table}/{digest}".format(table=table, digest=digest)
 
 
 def _ex_to_message(ex):
-    return getattr(ex, 'message', None) or str(ex) or repr(ex)
+    return getattr(ex, "message", None) or str(ex) or repr(ex)
 
 
 def _raise_for_status(response):
     """
-    Properly raise `IntegrityError` exceptions for CrateDB's `DuplicateKeyException` errors.
+    Raise `IntegrityError` exceptions for `DuplicateKeyException` errors.
     """
     try:
         return _raise_for_status_real(response)
@@ -204,29 +211,33 @@ def _raise_for_status(response):
 
 
 def _raise_for_status_real(response):
-    """ make sure that only crate.exceptions are raised that are defined in
-    the DB-API specification """
-    message = ''
+    """make sure that only crate.exceptions are raised that are defined in
+    the DB-API specification"""
+    message = ""
     if 400 <= response.status < 500:
-        message = '%s Client Error: %s' % (response.status, response.reason)
+        message = "%s Client Error: %s" % (response.status, response.reason)
     elif 500 <= response.status < 600:
-        message = '%s Server Error: %s' % (response.status, response.reason)
+        message = "%s Server Error: %s" % (response.status, response.reason)
     else:
         return
     if response.status == 503:
         raise ConnectionError(message)
     if response.headers.get("content-type", "").startswith("application/json"):
-        data = json.loads(response.data.decode('utf-8'))
-        error = data.get('error', {})
-        error_trace = data.get('error_trace', None)
+        data = json.loads(response.data.decode("utf-8"))
+        error = data.get("error", {})
+        error_trace = data.get("error_trace", None)
         if "results" in data:
-            errors = [res["error_message"] for res in data["results"]
-                      if res.get("error_message")]
+            errors = [
+                res["error_message"]
+                for res in data["results"]
+                if res.get("error_message")
+            ]
             if errors:
                 raise ProgrammingError("\n".join(errors))
         if isinstance(error, dict):
-            raise ProgrammingError(error.get('message', ''),
-                                   error_trace=error_trace)
+            raise ProgrammingError(
+                error.get("message", ""), error_trace=error_trace
+            )
         raise ProgrammingError(error, error_trace=error_trace)
     raise ProgrammingError(message)
 
@@ -247,9 +258,9 @@ def _server_url(server):
     http://demo.crate.io
     """
     if not _HTTP_PAT.match(server):
-        server = 'http://%s' % server
+        server = "http://%s" % server
     parsed = urlparse(server)
-    url = '%s://%s' % (parsed.scheme, parsed.netloc)
+    url = "%s://%s" % (parsed.scheme, parsed.netloc)
     return url
 
 
@@ -259,30 +270,36 @@ def _to_server_list(servers):
     return [_server_url(s) for s in servers]
 
 
-def _pool_kw_args(verify_ssl_cert, ca_cert, client_cert, client_key,
-                  timeout=None, pool_size=None):
-    ca_cert = ca_cert or os.environ.get('REQUESTS_CA_BUNDLE', None)
+def _pool_kw_args(
+    verify_ssl_cert,
+    ca_cert,
+    client_cert,
+    client_key,
+    timeout=None,
+    pool_size=None,
+):
+    ca_cert = ca_cert or os.environ.get("REQUESTS_CA_BUNDLE", None)
     if ca_cert and not os.path.exists(ca_cert):
         # Sanity check
         raise IOError('CA bundle file "{}" does not exist.'.format(ca_cert))
 
     kw = {
-        'ca_certs': ca_cert,
-        'cert_reqs': ssl.CERT_REQUIRED if verify_ssl_cert else ssl.CERT_NONE,
-        'cert_file': client_cert,
-        'key_file': client_key,
+        "ca_certs": ca_cert,
+        "cert_reqs": ssl.CERT_REQUIRED if verify_ssl_cert else ssl.CERT_NONE,
+        "cert_file": client_cert,
+        "key_file": client_key,
     }
     if timeout is not None:
         if isinstance(timeout, str):
             timeout = float(timeout)
-        kw['timeout'] = timeout
+        kw["timeout"] = timeout
     if pool_size is not None:
-        kw['maxsize'] = int(pool_size)
+        kw["maxsize"] = int(pool_size)
     return kw
 
 
 def _remove_certs_for_non_https(server, kwargs):
-    if server.lower().startswith('https'):
+    if server.lower().startswith("https"):
         return kwargs
     used_ssl_args = SSL_ONLY_ARGS & set(kwargs.keys())
     if used_ssl_args:
@@ -300,6 +317,7 @@ def _update_pool_kwargs_for_ssl_minimum_version(server, kwargs):
     """
     if Version(urllib3.__version__) >= Version("2"):
         from urllib3.util import parse_url
+
         scheme, _, host, port, *_ = parse_url(server)
         if scheme == "https":
             kwargs["ssl_minimum_version"] = ssl.TLSVersion.MINIMUM_SUPPORTED
@@ -307,24 +325,21 @@ def _update_pool_kwargs_for_ssl_minimum_version(server, kwargs):
 
 def _create_sql_payload(stmt, args, bulk_args):
     if not isinstance(stmt, str):
-        raise ValueError('stmt is not a string')
+        raise ValueError("stmt is not a string")
     if args and bulk_args:
-        raise ValueError('Cannot provide both: args and bulk_args')
+        raise ValueError("Cannot provide both: args and bulk_args")
 
-    data = {
-        'stmt': stmt
-    }
+    data = {"stmt": stmt}
     if args:
-        data['args'] = args
+        data["args"] = args
     if bulk_args:
-        data['bulk_args'] = bulk_args
+        data["bulk_args"] = bulk_args
     return json.dumps(data, cls=CrateJsonEncoder)
 
 
-def _get_socket_opts(keepalive=True,
-                     tcp_keepidle=None,
-                     tcp_keepintvl=None,
-                     tcp_keepcnt=None):
+def _get_socket_opts(
+    keepalive=True, tcp_keepidle=None, tcp_keepintvl=None, tcp_keepcnt=None
+):
     """
     Return an optional list of socket options for urllib3's HTTPConnection
     constructor.
@@ -337,23 +352,23 @@ def _get_socket_opts(keepalive=True,
 
     # hasattr check because some options depend on system capabilities
     # see https://docs.python.org/3/library/socket.html#socket.SOMAXCONN
-    if hasattr(socket, 'TCP_KEEPIDLE') and tcp_keepidle is not None:
+    if hasattr(socket, "TCP_KEEPIDLE") and tcp_keepidle is not None:
         opts.append((socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, tcp_keepidle))
-    if hasattr(socket, 'TCP_KEEPINTVL') and tcp_keepintvl is not None:
+    if hasattr(socket, "TCP_KEEPINTVL") and tcp_keepintvl is not None:
         opts.append((socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, tcp_keepintvl))
-    if hasattr(socket, 'TCP_KEEPCNT') and tcp_keepcnt is not None:
+    if hasattr(socket, "TCP_KEEPCNT") and tcp_keepcnt is not None:
         opts.append((socket.IPPROTO_TCP, socket.TCP_KEEPCNT, tcp_keepcnt))
 
     # additionally use urllib3's default socket options
-    return HTTPConnection.default_socket_options + opts
+    return list(HTTPConnection.default_socket_options) + opts
 
 
-class Client(object):
+class Client:
     """
     Crate connection client using CrateDB's HTTP API.
     """
 
-    SQL_PATH = '/_sql?types=true'
+    SQL_PATH = "/_sql?types=true"
     """Crate URI path for issuing SQL statements."""
 
     retry_interval = 30
@@ -362,25 +377,26 @@ class Client(object):
     default_server = "http://127.0.0.1:4200"
     """Default server to use if no servers are given on instantiation."""
 
-    def __init__(self,
-                 servers=None,
-                 timeout=None,
-                 backoff_factor=0,
-                 verify_ssl_cert=True,
-                 ca_cert=None,
-                 error_trace=False,
-                 cert_file=None,
-                 key_file=None,
-                 ssl_relax_minimum_version=False,
-                 username=None,
-                 password=None,
-                 schema=None,
-                 pool_size=None,
-                 socket_keepalive=True,
-                 socket_tcp_keepidle=None,
-                 socket_tcp_keepintvl=None,
-                 socket_tcp_keepcnt=None,
-                 ):
+    def __init__(
+        self,
+        servers=None,
+        timeout=None,
+        backoff_factor=0,
+        verify_ssl_cert=True,
+        ca_cert=None,
+        error_trace=False,
+        cert_file=None,
+        key_file=None,
+        ssl_relax_minimum_version=False,
+        username=None,
+        password=None,
+        schema=None,
+        pool_size=None,
+        socket_keepalive=True,
+        socket_tcp_keepidle=None,
+        socket_tcp_keepintvl=None,
+        socket_tcp_keepcnt=None,
+    ):
         if not servers:
             servers = [self.default_server]
         else:
@@ -396,22 +412,30 @@ class Client(object):
                 if url.password is not None:
                     password = url.password
             except Exception as ex:
-                logger.warning("Unable to decode credentials from database "
-                               "URI, so connecting to CrateDB without "
-                               "authentication: {ex}"
-                               .format(ex=ex))
+                logger.warning(
+                    "Unable to decode credentials from database "
+                    "URI, so connecting to CrateDB without "
+                    "authentication: {ex}".format(ex=ex)
+                )
 
         self._active_servers = servers
         self._inactive_servers = []
         pool_kw = _pool_kw_args(
-            verify_ssl_cert, ca_cert, cert_file, key_file, timeout, pool_size,
+            verify_ssl_cert,
+            ca_cert,
+            cert_file,
+            key_file,
+            timeout,
+            pool_size,
         )
-        pool_kw.update({
-            'socket_keepalive': socket_keepalive,
-            'socket_tcp_keepidle': socket_tcp_keepidle,
-            'socket_tcp_keepintvl': socket_tcp_keepintvl,
-            'socket_tcp_keepcnt': socket_tcp_keepcnt,
-        })
+        pool_kw.update(
+            {
+                "socket_keepalive": socket_keepalive,
+                "socket_tcp_keepidle": socket_tcp_keepidle,
+                "socket_tcp_keepintvl": socket_tcp_keepintvl,
+                "socket_tcp_keepcnt": socket_tcp_keepcnt,
+            }
+        )
         self.ssl_relax_minimum_version = ssl_relax_minimum_version
         self.backoff_factor = backoff_factor
         self.server_pool = {}
@@ -425,7 +449,7 @@ class Client(object):
 
         self.path = self.SQL_PATH
         if error_trace:
-            self.path += '&error_trace=true'
+            self.path += "&error_trace=true"
 
     def close(self):
         for server in self.server_pool.values():
@@ -433,8 +457,9 @@ class Client(object):
 
     def _create_server(self, server, **pool_kw):
         kwargs = _remove_certs_for_non_https(server, pool_kw)
-        # After updating to urllib3 v2, optionally retain support for TLS 1.0 and TLS 1.1,
-        # in order to support connectivity to older versions of CrateDB.
+        # After updating to urllib3 v2, optionally retain support
+        # for TLS 1.0 and TLS 1.1, in order to support connectivity
+        # to older versions of CrateDB.
         if self.ssl_relax_minimum_version:
             _update_pool_kwargs_for_ssl_minimum_version(server, kwargs)
         self.server_pool[server] = Server(server, **kwargs)
@@ -451,28 +476,26 @@ class Client(object):
             return None
 
         data = _create_sql_payload(stmt, parameters, bulk_parameters)
-        logger.debug(
-            'Sending request to %s with payload: %s', self.path, data)
-        content = self._json_request('POST', self.path, data=data)
+        logger.debug("Sending request to %s with payload: %s", self.path, data)
+        content = self._json_request("POST", self.path, data=data)
         logger.debug("JSON response for stmt(%s): %s", stmt, content)
 
         return content
 
     def server_infos(self, server):
-        response = self._request('GET', '/', server=server)
+        response = self._request("GET", "/", server=server)
         _raise_for_status(response)
         content = _json_from_response(response)
         node_name = content.get("name")
-        node_version = content.get('version', {}).get('number', '0.0.0')
+        node_version = content.get("version", {}).get("number", "0.0.0")
         return server, node_name, node_version
 
-    def blob_put(self, table, digest, data):
+    def blob_put(self, table, digest, data) -> bool:
         """
         Stores the contents of the file like @data object in a blob under the
         given table and digest.
         """
-        response = self._request('PUT', _blob_path(table, digest),
-                                 data=data)
+        response = self._request("PUT", _blob_path(table, digest), data=data)
         if response.status == 201:
             # blob created
             return True
@@ -482,40 +505,43 @@ class Client(object):
         if response.status in (400, 404):
             raise BlobLocationNotFoundException(table, digest)
         _raise_for_status(response)
+        return False
 
-    def blob_del(self, table, digest):
+    def blob_del(self, table, digest) -> bool:
         """
         Deletes the blob with given digest under the given table.
         """
-        response = self._request('DELETE', _blob_path(table, digest))
+        response = self._request("DELETE", _blob_path(table, digest))
         if response.status == 204:
             return True
         if response.status == 404:
             return False
         _raise_for_status(response)
+        return False
 
     def blob_get(self, table, digest, chunk_size=1024 * 128):
         """
         Returns a file like object representing the contents of the blob
         with the given digest.
         """
-        response = self._request('GET', _blob_path(table, digest), stream=True)
+        response = self._request("GET", _blob_path(table, digest), stream=True)
         if response.status == 404:
             raise DigestNotFoundException(table, digest)
         _raise_for_status(response)
         return response.stream(amt=chunk_size)
 
-    def blob_exists(self, table, digest):
+    def blob_exists(self, table, digest) -> bool:
         """
         Returns true if the blob with the given digest exists
         under the given table.
         """
-        response = self._request('HEAD', _blob_path(table, digest))
+        response = self._request("HEAD", _blob_path(table, digest))
         if response.status == 200:
             return True
         elif response.status == 404:
             return False
         _raise_for_status(response)
+        return False
 
     def _add_server(self, server):
         with self._lock:
@@ -537,42 +563,45 @@ class Client(object):
                     password=self.password,
                     backoff_factor=self.backoff_factor,
                     schema=self.schema,
-                    **kwargs
+                    **kwargs,
                 )
                 redirect_location = response.get_redirect_location()
                 if redirect_location and 300 <= response.status <= 308:
                     redirect_server = _server_url(redirect_location)
                     self._add_server(redirect_server)
                     return self._request(
-                        method, path, server=redirect_server, **kwargs)
+                        method, path, server=redirect_server, **kwargs
+                    )
                 if not server and response.status in SRV_UNAVAILABLE_STATUSES:
                     with self._lock:
                         # drop server from active ones
                         self._drop_server(next_server, response.reason)
                 else:
                     return response
-            except (MaxRetryError,
-                    ReadTimeoutError,
-                    SSLError,
-                    HTTPError,
-                    ProxyError,) as ex:
+            except (
+                MaxRetryError,
+                ReadTimeoutError,
+                SSLError,
+                HTTPError,
+                ProxyError,
+            ) as ex:
                 ex_message = _ex_to_message(ex)
                 if server:
                     raise ConnectionError(
                         "Server not available, exception: %s" % ex_message
-                    )
+                    ) from ex
                 preserve_server = False
                 if isinstance(ex, ProtocolError):
                     preserve_server = any(
                         t in [type(arg) for arg in ex.args]
                         for t in PRESERVE_ACTIVE_SERVER_EXCEPTIONS
                     )
-                if (not preserve_server):
+                if not preserve_server:
                     with self._lock:
                         # drop server from active ones
                         self._drop_server(next_server, ex_message)
             except Exception as e:
-                raise ProgrammingError(_ex_to_message(e))
+                raise ProgrammingError(_ex_to_message(e)) from e
 
     def _json_request(self, method, path, data):
         """
@@ -592,7 +621,7 @@ class Client(object):
         """
         with self._lock:
             inactive_server_count = len(self._inactive_servers)
-            for i in range(inactive_server_count):
+            for _ in range(inactive_server_count):
                 try:
                     ts, server, message = heapq.heappop(self._inactive_servers)
                 except IndexError:
@@ -600,12 +629,14 @@ class Client(object):
                 else:
                     if (ts + self.retry_interval) > time():
                         # Not yet, put it back
-                        heapq.heappush(self._inactive_servers,
-                                       (ts, server, message))
+                        heapq.heappush(
+                            self._inactive_servers, (ts, server, message)
+                        )
                     else:
                         self._active_servers.append(server)
-                        logger.warning("Restored server %s into active pool",
-                                       server)
+                        logger.warning(
+                            "Restored server %s into active pool", server
+                        )
 
             # if none is old enough, use oldest
             if not self._active_servers:
@@ -639,8 +670,9 @@ class Client(object):
         # if this is the last server raise exception, otherwise try next
         if not self._active_servers:
             raise ConnectionError(
-                ("No more Servers available, "
-                 "exception from last server: %s") % message)
+                ("No more Servers available, " "exception from last server: %s")
+                % message
+            )
 
     def _roundrobin(self):
         """
@@ -649,4 +681,4 @@ class Client(object):
         self._active_servers.append(self._active_servers.pop(0))
 
     def __repr__(self):
-        return '<Client {0}>'.format(str(self._active_servers))
+        return "<Client {0}>".format(str(self._active_servers))

--- a/src/crate/testing/util.py
+++ b/src/crate/testing/util.py
@@ -21,8 +21,7 @@
 import unittest
 
 
-class ClientMocked(object):
-
+class ClientMocked:
     active_servers = ["http://localhost:4200"]
 
     def __init__(self):
@@ -52,14 +51,15 @@ class ParametrizedTestCase(unittest.TestCase):
 
     https://eli.thegreenplace.net/2011/08/02/python-unit-testing-parametrized-test-cases
     """
+
     def __init__(self, methodName="runTest", param=None):
         super(ParametrizedTestCase, self).__init__(methodName)
         self.param = param
 
     @staticmethod
     def parametrize(testcase_klass, param=None):
-        """ Create a suite containing all tests taken from the given
-            subclass, passing them the parameter 'param'.
+        """Create a suite containing all tests taken from the given
+        subclass, passing them the parameter 'param'.
         """
         testloader = unittest.TestLoader()
         testnames = testloader.getTestCaseNames(testcase_klass)
@@ -69,7 +69,7 @@ class ParametrizedTestCase(unittest.TestCase):
         return suite
 
 
-class ExtraAssertions:
+class ExtraAssertions(unittest.TestCase):
     """
     Additional assert methods for unittest.
 
@@ -83,9 +83,13 @@ class ExtraAssertions:
             r = issubclass(cls, superclass)
         except TypeError:
             if not isinstance(cls, type):
-                self.fail(self._formatMessage(msg,
-                          '%r is not a class' % (cls,)))
+                self.fail(
+                    self._formatMessage(msg, "%r is not a class" % (cls,))
+                )
             raise
         if not r:
-            self.fail(self._formatMessage(msg,
-                      '%r is not a subclass of %r' % (cls, superclass)))
+            self.fail(
+                self._formatMessage(
+                    msg, "%r is not a subclass of %r" % (cls, superclass)
+                )
+            )

--- a/tests/client/settings.py
+++ b/tests/client/settings.py
@@ -25,7 +25,9 @@ from pathlib import Path
 
 
 def assets_path(*parts) -> str:
-    return str((project_root() / "tests" / "assets").joinpath(*parts).absolute())
+    return str(
+        (project_root() / "tests" / "assets").joinpath(*parts).absolute()
+    )
 
 
 def crate_path() -> str:
@@ -36,9 +38,8 @@ def project_root() -> Path:
     return Path(__file__).parent.parent.parent
 
 
-
 crate_port = 44209
 crate_transport_port = 44309
-localhost = '127.0.0.1'
+localhost = "127.0.0.1"
 crate_host = "{host}:{port}".format(host=localhost, port=crate_port)
 crate_uri = "http://%s" % crate_host

--- a/tests/client/test_connection.py
+++ b/tests/client/test_connection.py
@@ -1,24 +1,23 @@
 import datetime
+from unittest import TestCase
 
 from urllib3 import Timeout
 
+from crate.client import connect
 from crate.client.connection import Connection
 from crate.client.http import Client
-from crate.client import connect
-from unittest import TestCase
 
 from .settings import crate_host
 
 
 class ConnectionTest(TestCase):
-
     def test_connection_mock(self):
         """
         For testing purposes it is often useful to replace the client used for
         communication with the CrateDB server with a stub or mock.
 
-        This can be done by passing an object of the Client class when calling the
-        ``connect`` method.
+        This can be done by passing an object of the Client class when calling
+        the `connect` method.
         """
 
         class MyConnectionClient:
@@ -32,12 +31,17 @@ class ConnectionTest(TestCase):
 
         connection = connect([crate_host], client=MyConnectionClient())
         self.assertIsInstance(connection, Connection)
-        self.assertEqual(connection.client.server_infos("foo"), ('localhost:4200', 'my server', '0.42.0'))
+        self.assertEqual(
+            connection.client.server_infos("foo"),
+            ("localhost:4200", "my server", "0.42.0"),
+        )
 
     def test_lowest_server_version(self):
-        infos = [(None, None, '0.42.3'),
-                 (None, None, '0.41.8'),
-                 (None, None, 'not a version')]
+        infos = [
+            (None, None, "0.42.3"),
+            (None, None, "0.41.8"),
+            (None, None, "not a version"),
+        ]
 
         client = Client(servers="localhost:4200 localhost:4201 localhost:4202")
         client.server_infos = lambda server: infos.pop()
@@ -53,40 +57,45 @@ class ConnectionTest(TestCase):
         connection.close()
 
     def test_context_manager(self):
-        with connect('localhost:4200') as conn:
+        with connect("localhost:4200") as conn:
             pass
         self.assertEqual(conn._closed, True)
 
     def test_with_timezone(self):
         """
-        Verify the cursor objects will return timezone-aware `datetime` objects when requested to.
-        When switching the time zone at runtime on the connection object, only new cursor objects
-        will inherit the new time zone.
+        The cursor can return timezone-aware `datetime` objects when requested.
+
+        When switching the time zone at runtime on the connection object, only
+        new cursor objects will inherit the new time zone.
         """
 
         tz_mst = datetime.timezone(datetime.timedelta(hours=7), name="MST")
-        connection = connect('localhost:4200', time_zone=tz_mst)
+        connection = connect("localhost:4200", time_zone=tz_mst)
         cursor = connection.cursor()
         self.assertEqual(cursor.time_zone.tzname(None), "MST")
-        self.assertEqual(cursor.time_zone.utcoffset(None), datetime.timedelta(seconds=25200))
+        self.assertEqual(
+            cursor.time_zone.utcoffset(None), datetime.timedelta(seconds=25200)
+        )
 
         connection.time_zone = datetime.timezone.utc
         cursor = connection.cursor()
         self.assertEqual(cursor.time_zone.tzname(None), "UTC")
-        self.assertEqual(cursor.time_zone.utcoffset(None), datetime.timedelta(0))
+        self.assertEqual(
+            cursor.time_zone.utcoffset(None), datetime.timedelta(0)
+        )
 
     def test_timeout_float(self):
         """
         Verify setting the timeout value as a scalar (float) works.
         """
-        with connect('localhost:4200', timeout=2.42) as conn:
+        with connect("localhost:4200", timeout=2.42) as conn:
             self.assertEqual(conn.client._pool_kw["timeout"], 2.42)
 
     def test_timeout_string(self):
         """
         Verify setting the timeout value as a scalar (string) works.
         """
-        with connect('localhost:4200', timeout="2.42") as conn:
+        with connect("localhost:4200", timeout="2.42") as conn:
             self.assertEqual(conn.client._pool_kw["timeout"], 2.42)
 
     def test_timeout_object(self):
@@ -94,5 +103,5 @@ class ConnectionTest(TestCase):
         Verify setting the timeout value as a Timeout object works.
         """
         timeout = Timeout(connect=2.42, read=0.01)
-        with connect('localhost:4200', timeout=timeout) as conn:
+        with connect("localhost:4200", timeout=timeout) as conn:
             self.assertEqual(conn.client._pool_kw["timeout"], timeout)

--- a/tests/client/test_exceptions.py
+++ b/tests/client/test_exceptions.py
@@ -4,7 +4,6 @@ from crate.client import Error
 
 
 class ErrorTestCase(unittest.TestCase):
-
     def test_error_with_msg(self):
         err = Error("foo")
         self.assertEqual(str(err), "foo")

--- a/tests/client/tests.py
+++ b/tests/client/tests.py
@@ -1,18 +1,32 @@
 import doctest
 import unittest
 
+from .layer import (
+    HttpsTestServerLayer,
+    ensure_cratedb_layer,
+    makeSuite,
+    setUpCrateLayerBaseline,
+    setUpWithHttps,
+    tearDownDropEntitiesBaseline,
+)
 from .test_connection import ConnectionTest
 from .test_cursor import CursorTest
-from .test_http import HttpClientTest, KeepAliveClientTest, ThreadSafeHttpClientTest, ParamsTest, \
-    RetryOnTimeoutServerTest, RequestsCaBundleTest, TestUsernameSentAsHeader, TestCrateJsonEncoder, \
-    TestDefaultSchemaHeader
-from .layer import makeSuite, setUpWithHttps, HttpsTestServerLayer, setUpCrateLayerBaseline, \
-    tearDownDropEntitiesBaseline, ensure_cratedb_layer
+from .test_http import (
+    HttpClientTest,
+    KeepAliveClientTest,
+    ParamsTest,
+    RequestsCaBundleTest,
+    RetryOnTimeoutServerTest,
+    TestCrateJsonEncoder,
+    TestDefaultSchemaHeader,
+    TestUsernameSentAsHeader,
+    ThreadSafeHttpClientTest,
+)
 
 
 def test_suite():
     suite = unittest.TestSuite()
-    flags = (doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS)
+    flags = doctest.NORMALIZE_WHITESPACE | doctest.ELLIPSIS
 
     # Unit tests.
     suite.addTest(makeSuite(CursorTest))
@@ -26,24 +40,24 @@ def test_suite():
     suite.addTest(makeSuite(TestUsernameSentAsHeader))
     suite.addTest(makeSuite(TestCrateJsonEncoder))
     suite.addTest(makeSuite(TestDefaultSchemaHeader))
-    suite.addTest(doctest.DocTestSuite('crate.client.connection'))
-    suite.addTest(doctest.DocTestSuite('crate.client.http'))
+    suite.addTest(doctest.DocTestSuite("crate.client.connection"))
+    suite.addTest(doctest.DocTestSuite("crate.client.http"))
 
     s = doctest.DocFileSuite(
-        'docs/by-example/connection.rst',
-        'docs/by-example/cursor.rst',
+        "docs/by-example/connection.rst",
+        "docs/by-example/cursor.rst",
         module_relative=False,
         optionflags=flags,
-        encoding='utf-8'
+        encoding="utf-8",
     )
     suite.addTest(s)
 
     s = doctest.DocFileSuite(
-        'docs/by-example/https.rst',
+        "docs/by-example/https.rst",
         module_relative=False,
         setUp=setUpWithHttps,
         optionflags=flags,
-        encoding='utf-8'
+        encoding="utf-8",
     )
     s.layer = HttpsTestServerLayer()
     suite.addTest(s)
@@ -52,14 +66,14 @@ def test_suite():
     layer = ensure_cratedb_layer()
 
     s = doctest.DocFileSuite(
-        'docs/by-example/http.rst',
-        'docs/by-example/client.rst',
-        'docs/by-example/blob.rst',
+        "docs/by-example/http.rst",
+        "docs/by-example/client.rst",
+        "docs/by-example/blob.rst",
         module_relative=False,
         setUp=setUpCrateLayerBaseline,
         tearDown=tearDownDropEntitiesBaseline,
         optionflags=flags,
-        encoding='utf-8'
+        encoding="utf-8",
     )
     s.layer = layer
     suite.addTest(s)

--- a/tests/testing/test_layer.py
+++ b/tests/testing/test_layer.py
@@ -22,93 +22,111 @@ import json
 import os
 import tempfile
 import urllib
-from verlib2 import Version
-from unittest import TestCase, mock
 from io import BytesIO
+from unittest import TestCase, mock
 
 import urllib3
+from verlib2 import Version
 
 import crate
-from crate.testing.layer import CrateLayer, prepend_http, http_url_from_host_port, wait_for_http_url
+from crate.testing.layer import (
+    CrateLayer,
+    http_url_from_host_port,
+    prepend_http,
+    wait_for_http_url,
+)
+
 from .settings import crate_path
 
 
 class LayerUtilsTest(TestCase):
-
     def test_prepend_http(self):
-        host = prepend_http('localhost')
-        self.assertEqual('http://localhost', host)
-        host = prepend_http('http://localhost')
-        self.assertEqual('http://localhost', host)
-        host = prepend_http('https://localhost')
-        self.assertEqual('https://localhost', host)
-        host = prepend_http('http')
-        self.assertEqual('http://http', host)
+        host = prepend_http("localhost")
+        self.assertEqual("http://localhost", host)
+        host = prepend_http("http://localhost")
+        self.assertEqual("http://localhost", host)
+        host = prepend_http("https://localhost")
+        self.assertEqual("https://localhost", host)
+        host = prepend_http("http")
+        self.assertEqual("http://http", host)
 
     def test_http_url(self):
         url = http_url_from_host_port(None, None)
         self.assertEqual(None, url)
-        url = http_url_from_host_port('localhost', None)
+        url = http_url_from_host_port("localhost", None)
         self.assertEqual(None, url)
         url = http_url_from_host_port(None, 4200)
         self.assertEqual(None, url)
-        url = http_url_from_host_port('localhost', 4200)
-        self.assertEqual('http://localhost:4200', url)
-        url = http_url_from_host_port('https://crate', 4200)
-        self.assertEqual('https://crate:4200', url)
+        url = http_url_from_host_port("localhost", 4200)
+        self.assertEqual("http://localhost:4200", url)
+        url = http_url_from_host_port("https://crate", 4200)
+        self.assertEqual("https://crate:4200", url)
 
     def test_wait_for_http(self):
-        log = BytesIO(b'[i.c.p.h.CrateNettyHttpServerTransport] [crate] publish_address {127.0.0.1:4200}')
+        log = BytesIO(
+            b"[i.c.p.h.CrateNettyHttpServerTransport] [crate] publish_address {127.0.0.1:4200}"  # noqa: E501
+        )
         addr = wait_for_http_url(log)
-        self.assertEqual('http://127.0.0.1:4200', addr)
-        log = BytesIO(b'[i.c.p.h.CrateNettyHttpServerTransport] [crate] publish_address {}')
+        self.assertEqual("http://127.0.0.1:4200", addr)
+        log = BytesIO(
+            b"[i.c.p.h.CrateNettyHttpServerTransport] [crate] publish_address {}"  # noqa: E501
+        )
         addr = wait_for_http_url(log=log, timeout=1)
         self.assertEqual(None, addr)
 
-    @mock.patch.object(crate.testing.layer, "_download_and_extract", lambda uri, directory: None)
+    @mock.patch.object(
+        crate.testing.layer,
+        "_download_and_extract",
+        lambda uri, directory: None,
+    )
     def test_layer_from_uri(self):
         """
         The CrateLayer can also be created by providing an URI that points to
         a CrateDB tarball.
         """
-        with urllib.request.urlopen("https://crate.io/versions.json") as response:
+        with urllib.request.urlopen(
+            "https://crate.io/versions.json"
+        ) as response:
             versions = json.loads(response.read().decode())
             version = versions["crate_testing"]
 
         self.assertGreaterEqual(Version(version), Version("4.5.0"))
 
-        uri = "https://cdn.crate.io/downloads/releases/crate-{}.tar.gz".format(version)
+        uri = "https://cdn.crate.io/downloads/releases/crate-{}.tar.gz".format(
+            version
+        )
         layer = CrateLayer.from_uri(uri, name="crate-by-uri", http_port=42203)
         self.assertIsInstance(layer, CrateLayer)
 
-    @mock.patch.dict('os.environ', {}, clear=True)
+    @mock.patch.dict("os.environ", {}, clear=True)
     def test_java_home_env_not_set(self):
         with tempfile.TemporaryDirectory() as tmpdir:
-            layer = CrateLayer('java-home-test', tmpdir)
-            # JAVA_HOME must not be set to `None`, since it would be interpreted as a
-            # string 'None', and therefore intepreted as a path
-            self.assertEqual(layer.env['JAVA_HOME'], '')
+            layer = CrateLayer("java-home-test", tmpdir)
+            # JAVA_HOME must not be set to `None`: It would be literally
+            # interpreted as a string 'None', which is an invalid path.
+            self.assertEqual(layer.env["JAVA_HOME"], "")
 
-    @mock.patch.dict('os.environ', {}, clear=True)
+    @mock.patch.dict("os.environ", {}, clear=True)
     def test_java_home_env_set(self):
-        java_home = '/usr/lib/jvm/java-11-openjdk-amd64'
+        java_home = "/usr/lib/jvm/java-11-openjdk-amd64"
         with tempfile.TemporaryDirectory() as tmpdir:
-            os.environ['JAVA_HOME'] = java_home
-            layer = CrateLayer('java-home-test', tmpdir)
-            self.assertEqual(layer.env['JAVA_HOME'], java_home)
+            os.environ["JAVA_HOME"] = java_home
+            layer = CrateLayer("java-home-test", tmpdir)
+            self.assertEqual(layer.env["JAVA_HOME"], java_home)
 
-    @mock.patch.dict('os.environ', {}, clear=True)
+    @mock.patch.dict("os.environ", {}, clear=True)
     def test_java_home_env_override(self):
-        java_11_home = '/usr/lib/jvm/java-11-openjdk-amd64'
-        java_12_home = '/usr/lib/jvm/java-12-openjdk-amd64'
+        java_11_home = "/usr/lib/jvm/java-11-openjdk-amd64"
+        java_12_home = "/usr/lib/jvm/java-12-openjdk-amd64"
         with tempfile.TemporaryDirectory() as tmpdir:
-            os.environ['JAVA_HOME'] = java_11_home
-            layer = CrateLayer('java-home-test', tmpdir, env={'JAVA_HOME': java_12_home})
-            self.assertEqual(layer.env['JAVA_HOME'], java_12_home)
+            os.environ["JAVA_HOME"] = java_11_home
+            layer = CrateLayer(
+                "java-home-test", tmpdir, env={"JAVA_HOME": java_12_home}
+            )
+            self.assertEqual(layer.env["JAVA_HOME"], java_12_home)
 
 
 class LayerTest(TestCase):
-
     def test_basic(self):
         """
         This layer starts and stops a ``Crate`` instance on a given host, port,
@@ -118,13 +136,14 @@ class LayerTest(TestCase):
         port = 44219
         transport_port = 44319
 
-        layer = CrateLayer('crate',
-                           crate_home=crate_path(),
-                           host='127.0.0.1',
-                           port=port,
-                           transport_port=transport_port,
-                           cluster_name='my_cluster'
-                           )
+        layer = CrateLayer(
+            "crate",
+            crate_home=crate_path(),
+            host="127.0.0.1",
+            port=port,
+            transport_port=transport_port,
+            cluster_name="my_cluster",
+        )
 
         # The working directory is defined on layer instantiation.
         # It is sometimes required to know it before starting the layer.
@@ -142,7 +161,7 @@ class LayerTest(TestCase):
         http = urllib3.PoolManager()
 
         stats_uri = "http://127.0.0.1:{0}/".format(port)
-        response = http.request('GET', stats_uri)
+        response = http.request("GET", stats_uri)
         self.assertEqual(response.status, 200)
 
         # The layer can be shutdown using its `stop()` method.
@@ -150,91 +169,98 @@ class LayerTest(TestCase):
 
     def test_dynamic_http_port(self):
         """
-        It is also possible to define a port range instead of a static HTTP port for the layer.
+        Verify defining a port range instead of a static HTTP port.
 
-        Crate will start with the first available port in the given range and the test
-        layer obtains the chosen port from the startup logs of the Crate process.
-        Note, that this feature requires a logging configuration with at least loglevel
-        ``INFO`` on ``http``.
+        CrateDB will start with the first available port in the given range and
+        the test layer obtains the chosen port from the startup logs of the
+        CrateDB process.
+
+        Note that this feature requires a logging configuration with at least
+        loglevel ``INFO`` on ``http``.
         """
-        port = '44200-44299'
-        layer = CrateLayer('crate', crate_home=crate_path(), port=port)
+        port = "44200-44299"
+        layer = CrateLayer("crate", crate_home=crate_path(), port=port)
         layer.start()
         self.assertRegex(layer.crate_servers[0], r"http://127.0.0.1:442\d\d")
         layer.stop()
 
     def test_default_settings(self):
         """
-        Starting a CrateDB layer leaving out optional parameters will apply the following
-        defaults.
+        Starting a CrateDB layer leaving out optional parameters will apply
+        the following defaults.
 
-        The default http port is the first free port in the range of ``4200-4299``,
-        the default transport port is the first free port in the range of ``4300-4399``,
-        the host defaults to ``127.0.0.1``.
+        The default http port is the first free port in the range of
+        ``4200-4299``, the default transport port is the first free port in
+        the range of ``4300-4399``, the host defaults to ``127.0.0.1``.
 
         The command to call is ``bin/crate`` inside the ``crate_home`` path.
         The default config file is ``config/crate.yml`` inside ``crate_home``.
         The default cluster name will be auto generated using the HTTP port.
         """
-        layer = CrateLayer('crate_defaults', crate_home=crate_path())
+        layer = CrateLayer("crate_defaults", crate_home=crate_path())
         layer.start()
         self.assertEqual(layer.crate_servers[0], "http://127.0.0.1:4200")
         layer.stop()
 
     def test_additional_settings(self):
         """
-        The ``Crate`` layer can be started with additional settings as well.
-        Add a dictionary for keyword argument ``settings`` which contains your settings.
-        Those additional setting will override settings given as keyword argument.
+        The CrateDB test layer can be started with additional settings as well.
 
-        The settings will be handed over to the ``Crate`` process with the ``-C`` flag.
-        So the setting ``threadpool.bulk.queue_size: 100`` becomes
-        the command line flag: ``-Cthreadpool.bulk.queue_size=100``::
+        Add a dictionary for keyword argument ``settings`` which contains your
+        settings. Those additional setting will override settings given as
+        keyword argument.
+
+        The settings will be handed over to the ``Crate`` process with the
+        ``-C`` flag. So, the setting ``threadpool.bulk.queue_size: 100``
+        becomes the command line flag: ``-Cthreadpool.bulk.queue_size=100``::
         """
         layer = CrateLayer(
-            'custom',
+            "custom",
             crate_path(),
             port=44401,
             settings={
                 "cluster.graceful_stop.min_availability": "none",
-                "http.port": 44402
-            }
+                "http.port": 44402,
+            },
         )
         layer.start()
         self.assertEqual(layer.crate_servers[0], "http://127.0.0.1:44402")
-        self.assertIn("-Ccluster.graceful_stop.min_availability=none", layer.start_cmd)
+        self.assertIn(
+            "-Ccluster.graceful_stop.min_availability=none", layer.start_cmd
+        )
         layer.stop()
 
     def test_verbosity(self):
         """
-        The test layer hides the standard output of Crate per default. To increase the
-        verbosity level the additional keyword argument ``verbose`` needs to be set
-        to ``True``::
+        The test layer hides the standard output of Crate per default.
+
+        To increase the verbosity level, the additional keyword argument
+        ``verbose`` needs to be set to ``True``::
         """
-        layer = CrateLayer('crate',
-                           crate_home=crate_path(),
-                           verbose=True)
+        layer = CrateLayer("crate", crate_home=crate_path(), verbose=True)
         layer.start()
         self.assertTrue(layer.verbose)
         layer.stop()
 
     def test_environment_variables(self):
         """
-        It is possible to provide environment variables for the ``Crate`` testing
-        layer.
+        Verify providing environment variables for the CrateDB testing layer.
         """
-        layer = CrateLayer('crate',
-                           crate_home=crate_path(),
-                           env={"CRATE_HEAP_SIZE": "300m"})
+        layer = CrateLayer(
+            "crate", crate_home=crate_path(), env={"CRATE_HEAP_SIZE": "300m"}
+        )
 
         layer.start()
 
         sql_uri = layer.crate_servers[0] + "/_sql"
 
         http = urllib3.PoolManager()
-        response = http.urlopen('POST', sql_uri,
-                                body='{"stmt": "select heap[\'max\'] from sys.nodes"}')
-        json_response = json.loads(response.data.decode('utf-8'))
+        response = http.urlopen(
+            "POST",
+            sql_uri,
+            body='{"stmt": "select heap[\'max\'] from sys.nodes"}',
+        )
+        json_response = json.loads(response.data.decode("utf-8"))
 
         self.assertEqual(json_response["rows"][0][0], 314572800)
 
@@ -243,25 +269,25 @@ class LayerTest(TestCase):
     def test_cluster(self):
         """
         To start a cluster of ``Crate`` instances, give each instance the same
-        ``cluster_name``. If you want to start instances on the same machine then
+        ``cluster_name``. If you want to start instances on the same machine,
         use value ``_local_`` for ``host`` and give every node different ports::
         """
         cluster_layer1 = CrateLayer(
-            'crate1',
+            "crate1",
             crate_path(),
-            host='_local_',
-            cluster_name='my_cluster',
+            host="_local_",
+            cluster_name="my_cluster",
         )
         cluster_layer2 = CrateLayer(
-            'crate2',
+            "crate2",
             crate_path(),
-            host='_local_',
-            cluster_name='my_cluster',
-            settings={"discovery.initial_state_timeout": "10s"}
+            host="_local_",
+            cluster_name="my_cluster",
+            settings={"discovery.initial_state_timeout": "10s"},
         )
 
-        # If we start both layers, they will, after a small amount of time, find each other
-        # and form a cluster.
+        # If we start both layers, they will, after a small amount of time,
+        # find each other, and form a cluster.
         cluster_layer1.start()
         cluster_layer2.start()
 
@@ -270,13 +296,18 @@ class LayerTest(TestCase):
 
         def num_cluster_nodes(crate_layer):
             sql_uri = crate_layer.crate_servers[0] + "/_sql"
-            response = http.urlopen('POST', sql_uri, body='{"stmt":"select count(*) from sys.nodes"}')
-            json_response = json.loads(response.data.decode('utf-8'))
+            response = http.urlopen(
+                "POST",
+                sql_uri,
+                body='{"stmt":"select count(*) from sys.nodes"}',
+            )
+            json_response = json.loads(response.data.decode("utf-8"))
             return json_response["rows"][0][0]
 
         # We might have to wait a moment before the cluster is finally created.
         num_nodes = num_cluster_nodes(cluster_layer1)
         import time
+
         retries = 0
         while num_nodes < 2:  # pragma: no cover
             time.sleep(1)

--- a/tests/testing/tests.py
+++ b/tests/testing/tests.py
@@ -21,8 +21,8 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import unittest
-from .test_layer import LayerUtilsTest, LayerTest
 
+from .test_layer import LayerTest, LayerUtilsTest
 
 makeSuite = unittest.TestLoader().loadTestsFromTestCase
 


### PR DESCRIPTION
## About
- Run the ruff code formatter and linter on the code base, and the mypy type checker.
- Invoke the "lint" job also on CI.

## Rationale
Before releasing 1.0.0, we would like to get the shape of the repository in order. This patch is one in a series to support that.

## Details
No other functional changes inside.

## References
- GH-659
