### PR TITLE
Sandbox: Optionally use `uv` package manager to save cycles

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,6 +43,9 @@ jobs:
           cache-dependency-path: |
             setup.py
 
+      - name: Install uv
+        uses: yezz123/setup-uv@v4
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
@@ -55,7 +58,7 @@ jobs:
 
       - name: Install project
         run: |
-          pip install --editable=.[test]
+          uv pip install --editable=.[test]
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -32,6 +32,9 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'setup.py'
 
+      - name: Install uv
+        uses: yezz123/setup-uv@v4
+
       - name: Invoke tests
         run: |
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,14 @@ jobs:
           cache: 'pip'
           cache-dependency-path: 'setup.py'
 
+      - name: Install uv
+        uses: yezz123/setup-uv@v4
+
       - name: Build package
         run: |
-          python -m pip install twine wheel
-          python setup.py sdist bdist_wheel
-          twine check dist/*.tar.gz
+          uv pip install build twine wheel
+          python -m build
+          twine check dist/*
 
       - name: Publish package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -47,6 +47,9 @@ jobs:
           cache: 'pip'
           cache-dependency-path: setup.py
 
+      - name: Install uv
+        uses: yezz123/setup-uv@v4
+
       - name: Invoke tests
         run: |
 

--- a/DEVELOP.rst
+++ b/DEVELOP.rst
@@ -5,6 +5,12 @@ CrateDB Python developer guide
 Setup
 =====
 
+Optionally install Python package and project manager ``uv``,
+in order to significantly speed up the package installation::
+
+    {apt,brew,pip,zypper} install uv
+    alias pip="uv pip"
+
 To start things off, bootstrap the sandbox environment::
 
     git clone https://github.com/crate/crate-python

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -87,12 +87,25 @@ function finalize() {
 
 }
 
+function activate_uv() {
+  if command -v uv; then
+    function pip() {
+      uv pip "$@"
+    }
+  fi
+}
+function deactivate_uv() {
+  unset -f pip
+}
+
 function main() {
+    activate_uv
     ensure_virtualenv
     activate_virtualenv
     before_setup
     setup_package
     run_buildout
+    deactivate_uv
     finalize
 }
 


### PR DESCRIPTION
## About
[uv](https://docs.astral.sh/uv/) has a [pip interface](https://docs.astral.sh/uv/#the-pip-interface), that works pretty well emulating all sorts of `pip` incantations already.

## Details
Aliasing vanilla `pip` has been verified on my workstation, and it also works pretty well, so we can offer it as an optional sandbox feature without needing to populate all invocation spots where `pip` is used.
