### PR TITLE
CI: Use CrateDB `nightly` for PRs on Linux, lock version only on macOS

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,23 +16,23 @@ jobs:
      on ${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        os: ['ubuntu-22.04', 'macos-latest']
+        os: ['ubuntu-22.04']
         python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
-        cratedb-version: ['5.8.3']
+        cratedb-version: ['nightly']
 
         # To save resources, only verify the most recent Python versions on macOS.
-        exclude:
+        include:
           - os: 'macos-latest'
-            python-version: '3.7'
+            cratedb-version: '5.9.2'
+            python-version: '3.11'
           - os: 'macos-latest'
-            python-version: '3.8'
+            cratedb-version: '5.9.2'
+            python-version: '3.12'
           - os: 'macos-latest'
-            python-version: '3.9'
-          - os: 'macos-latest'
-            python-version: '3.10'
-
-      fail-fast: false
+            cratedb-version: '5.9.2'
+            python-version: '3.13'
 
     env:
       CRATEDB_VERSION: ${{ matrix.cratedb-version }}


### PR DESCRIPTION
## Problem
There are no nightly builds for macOS, so the test matrix has an anomaly. C'est la vie.

## Improvement
By restructuring this spot on the CI configuration, at least we don't need to bump versions manually any longer to prevent falling behind CrateDB development. While this just applies to the Linux slot, it is much better than nothing, and before.
