### PR TITLE
Error handling: Use `ValueError` exceptions instead of `assert`

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -14,6 +14,10 @@ Unreleased
   server stacktraces into exception messages.
 - Refactoring: The module namespace ``crate.client.test_util`` has been
   renamed to ``crate.testing.util``.
+- Error handling: At two spots in cursor / value converter handling, where
+  ``assert`` statements have been used, ``ValueError`` exceptions are raised
+  now.
+
 
 .. _Migrate from crate.client to sqlalchemy-cratedb: https://cratedb.com/docs/sqlalchemy-cratedb/migrate-from-crate-client.html
 .. _sqlalchemy-cratedb: https://pypi.org/project/sqlalchemy-cratedb/

--- a/src/crate/client/cursor.py
+++ b/src/crate/client/cursor.py
@@ -222,9 +222,11 @@ class Cursor:
         """
         Iterate rows, apply type converters, and generate converted rows.
         """
-        assert (  # noqa: S101
-            "col_types" in self._result and self._result["col_types"]
-        ), "Unable to apply type conversion without `col_types` information"
+        if not ("col_types" in self._result and self._result["col_types"]):
+            raise ValueError(
+                "Unable to apply type conversion "
+                "without `col_types` information"
+            )
 
         # Resolve `col_types` definition to converter functions. Running
         # the lookup redundantly on each row loop iteration would be a
@@ -302,10 +304,10 @@ class Cursor:
         """
         UTC offset in string format (e.g. `+0530`) to `datetime.timezone`.
         """
-        # TODO: Remove use of `assert`. Better use exceptions?
-        assert (  # noqa: S101
-            len(tz) == 5
-        ), f"Time zone '{tz}' is given in invalid UTC offset format"
+        if len(tz) != 5:
+            raise ValueError(
+                f"Time zone '{tz}' is given in invalid UTC offset format"
+            )
         try:
             hours = int(tz[:3])
             minutes = int(tz[0] + tz[3:])

--- a/tests/client/test_cursor.py
+++ b/tests/client/test_cursor.py
@@ -116,7 +116,7 @@ class CursorTest(TestCase):
         Verify the cursor trips when trying to use invalid UTC offset strings.
         """
         connection = self.get_mocked_connection()
-        with self.assertRaises(AssertionError) as ex:
+        with self.assertRaises(ValueError) as ex:
             connection.cursor(time_zone="foobar")
         self.assertEqual(
             str(ex.exception),


### PR DESCRIPTION
## About
Chore. Carry-over from https://github.com/crate/crate-python/pull/660#discussion_r1825654061.
