### PR TITLE
Dependencies: Remove version pinning of urllib3 and verlib2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ setup(
     packages=find_packages("src"),
     namespace_packages=["crate"],
     install_requires=[
-        "urllib3<2.3",
-        "verlib2==0.2.0",
+        "urllib3",
+        "verlib2",
     ],
     extras_require={
         "doc": [


### PR DESCRIPTION
## About
A library mostly shouldn't apply version pinning when not exactly needed. Only applications usually do, and libraries should be able to cope with different up- and downstream-versions.

Considering that both runtime dependencies are stable on their own, this should not cause too many forseeable headaches. When urllib3 v3 will be released, it might be different, but honestly I can't imagine it will be breaking its designated interface too much, if at all.

