### PR TITLE
CI: Fix "nightly" job: flake8 has been replaced with ruff. Also, add Python 3.13.

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
         cratedb-version: ['nightly']
 
       fail-fast: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -48,7 +48,7 @@ jobs:
           echo "Invoking tests with CrateDB ${CRATEDB_VERSION}"
 
           # Run linter.
-          flake8 src bin
+          poe lint
           
           # Run tests.
           bin/test -vvv


### PR DESCRIPTION
## About
Aftermath fixes to recent project/repository updates.
- GH-660
