### PR TITLE
Python: Fix "implicit namespace packages" migration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changes for crate
 
 Unreleased
 ==========
+- Python: Fixed "implicit namespace packages" migration by omitting
+  ``__init__.py`` from ``crate`` namespace package, see `PEP 420`_
+  and `Package Discovery and Namespace Package » Finding namespace packages`_.
+
 
 2024/11/05 1.0.0
 ================
@@ -44,6 +48,7 @@ Unreleased
 
 
 .. _Migrate from crate.client to sqlalchemy-cratedb: https://cratedb.com/docs/sqlalchemy-cratedb/migrate-from-crate-client.html
+.. _Package Discovery and Namespace Package » Finding namespace packages: https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#namespace-packages
 .. _PEP 420: https://peps.python.org/pep-0420/
 .. _sqlalchemy-cratedb: https://pypi.org/project/sqlalchemy-cratedb/
 


### PR DESCRIPTION
## About
... by omitting `__init__.py` from `crate` namespace package altogether, see "PEP 420" [1] and "Package Discovery and Namespace Package » Finding namespace packages" [2].

[1] https://peps.python.org/pep-0420/
[2] https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#namespace-packages

## References
- https://github.com/crate/crate-python/pull/666
- https://github.com/crate/crash/pull/453
- https://github.com/crate/crate-qa/pull/327