### PR TITLE
Chore: Suppress unqualified CodeQL admonitions

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,8 @@ jobs:
           languages: ${{ matrix.language }}
           config-file: ./.github/codeql.yml
           queries: +security-and-quality
+          # run an 'alert-suppression' query
+          packs: "codeql/${{ matrix.language }}-queries:AlertSuppression.ql"
 
       #- name: Autobuild
       #  uses: github/codeql-action/autobuild@v2
@@ -62,4 +64,21 @@ jobs:
           uv pip install --system '.[test]'
 
       - name: Perform CodeQL Analysis
+        id: analyze
         uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{matrix.language}}"
+          # define the output folder for SARIF files
+          output: sarif-results
+
+      # Unlock inline mechanism to suppress CodeQL warnings.
+      # https://github.com/github/codeql/issues/11427#issuecomment-1721059096
+      - name: Dismiss alerts
+        # if: github.ref == 'refs/heads/main'
+        uses: advanced-security/dismiss-alerts@v1
+        with:
+          # specify a 'sarif-id' and 'sarif-file'
+          sarif-id: ${{ steps.analyze.outputs.sarif-id }}
+          sarif-file: sarif-results/${{ matrix.language }}.sarif
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/src/crate/client/__init__.py
+++ b/src/crate/client/__init__.py
@@ -31,6 +31,7 @@ __all__ = [
 # regex!
 __version__ = "1.0.0"
 
+# codeql[py/unused-global-variable]
 apilevel = "2.0"
 threadsafety = 1
 paramstyle = "qmark"


### PR DESCRIPTION
## About
GitHub's CodeQL flags [1] a few spots unqualified with "Unused global variable" [2].

![image](https://github.com/user-attachments/assets/6c8cf5df-7cc0-48d9-8a8f-6246c12ea575)

## Solution?
Based on a suggestion [3], this patch attempts to use the `advanced-security/dismiss-alerts` [4] GitHub Action recipe to provide measures to suppress CodeQL flagging by using inline code annotations.

[1] https://github.com/crate/crate-python/security/code-scanning
[2] https://codeql.github.com/codeql-query-help/python/py-unused-global-variable/
[3] https://github.com/github/codeql/issues/11427#issuecomment-1721059096
[4] https://github.com/advanced-security/dismiss-alerts

## References
- https://github.com/advanced-security/dismiss-alerts/issues/118