### PR TITLE
Add missing `id:` field

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -62,6 +62,7 @@ jobs:
           uv pip install --system '.[test]'
 
       - name: Perform CodeQL Analysis
+        id: analyze
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement

Without `id: analyze` the `steps.analyze.output` values will be undefined:
https://github.com/crate/crate-python/blob/31f53c026455902e76d1bae96d172e7cb21d67be/.github/workflows/codeql.yml#L79-L80

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes https://github.com/advanced-security/dismiss-alerts/issues/118
