### PR TITLE
Use `orjson` to improve JSON marshalling performance

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,17 @@ Changes for crate
 Unreleased
 ==========
 
+- Switched JSON encoder to use the `orjson`_ library, to improve JSON
+  marshalling performance. Thanks, @widmogrod.
+  orjson is fast and in some spots even more correct when compared against
+  Python's stdlib ``json`` module. Contrary to the stdlib variant, orjson
+  will serialize to ``bytes`` instead of ``str``. Please also note it
+  will not deserialize to dataclasses, UUIDs, decimals, etc., or support
+  ``object_hook``. Within ``crate-python``, it is applied with an encoder
+  function for additional type support about Python's ``Decimal`` type and
+  freezegun's ``FakeDatetime`` type.
+
+.. _orjson: https://github.com/ijl/orjson
 
 2024/11/23 1.0.1
 ================

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,15 +7,21 @@ Unreleased
 
 - Switched JSON encoder to use the `orjson`_ library, to improve JSON
   marshalling performance. Thanks, @widmogrod.
+
   orjson is fast and in some spots even more correct when compared against
   Python's stdlib ``json`` module. Contrary to the stdlib variant, orjson
-  will serialize to ``bytes`` instead of ``str``. Please also note it
-  will not deserialize to dataclasses, UUIDs, decimals, etc., or support
-  ``object_hook``. Within ``crate-python``, it is applied with an encoder
-  function for additional type support about Python's ``Decimal`` type and
-  freezegun's ``FakeDatetime`` type.
+  will serialize to ``bytes`` instead of ``str``. When sending data to CrateDB,
+  ``crate-python`` uses a custom encoder to add support for additional data
+  types.
+
+  - Python's ``Decimal`` type will be serialized to ``str``.
+  - Python's ``dt.datetime`` and ``dt.date`` types will be serialized to
+    ``int`` (``LONG``) after converting to milliseconds since epoch, to
+    optimally accommodate CrateDB's `TIMESTAMP`_ representation.
+  - NumPy's data types will be handled by ``orjson`` without any ado.
 
 .. _orjson: https://github.com/ijl/orjson
+.. _TIMESTAMP: https://cratedb.com/docs/crate/reference/en/latest/general/ddl/data-types.html#type-timestamp
 
 2024/11/23 1.0.1
 ================

--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ setup(
     packages=find_namespace_packages("src"),
     package_dir={"": "src"},
     install_requires=[
+        "orjson<4",
         "urllib3",
         "verlib2",
     ],

--- a/tests/client/test_http.py
+++ b/tests/client/test_http.py
@@ -318,7 +318,7 @@ class HttpClientTest(TestCase):
         # convert string to dict
         # because the order of the keys isn't deterministic
         data = json.loads(request.call_args[1]["data"])
-        self.assertEqual(data["args"], ["2015-02-28T07:31:40"])
+        self.assertEqual(data["args"], [1425108700000])
         client.close()
 
     @patch(REQUEST, autospec=True)
@@ -329,7 +329,7 @@ class HttpClientTest(TestCase):
         day = dt.date(2016, 4, 21)
         client.sql("insert into users (dt) values (?)", (day,))
         data = json.loads(request.call_args[1]["data"])
-        self.assertEqual(data["args"], ["2016-04-21"])
+        self.assertEqual(data["args"], [1461196800000])
         client.close()
 
     def test_socket_options_contain_keepalive(self):
@@ -725,9 +725,9 @@ class TestCrateJsonEncoder(TestCase):
     def test_naive_datetime(self):
         data = dt.datetime.fromisoformat("2023-06-26T09:24:00.123")
         result = json_dumps(data)
-        self.assertEqual(result, b'"2023-06-26T09:24:00.123000"')
+        self.assertEqual(result, b"1687771440123")
 
     def test_aware_datetime(self):
         data = dt.datetime.fromisoformat("2023-06-26T09:24:00.123+02:00")
         result = json_dumps(data)
-        self.assertEqual(result, b'"2023-06-26T09:24:00.123000+02:00"')
+        self.assertEqual(result, b"1687764240123")

--- a/tests/client/test_http.py
+++ b/tests/client/test_http.py
@@ -49,9 +49,9 @@ from crate.client.exceptions import (
 )
 from crate.client.http import (
     Client,
-    CrateJsonEncoder,
     _get_socket_opts,
     _remove_certs_for_non_https,
+    json_dumps,
 )
 
 REQUEST = "crate.client.http.Server.request"
@@ -318,7 +318,7 @@ class HttpClientTest(TestCase):
         # convert string to dict
         # because the order of the keys isn't deterministic
         data = json.loads(request.call_args[1]["data"])
-        self.assertEqual(data["args"], [1425108700000])
+        self.assertEqual(data["args"], ["2015-02-28T07:31:40"])
         client.close()
 
     @patch(REQUEST, autospec=True)
@@ -329,7 +329,7 @@ class HttpClientTest(TestCase):
         day = dt.date(2016, 4, 21)
         client.sql("insert into users (dt) values (?)", (day,))
         data = json.loads(request.call_args[1]["data"])
-        self.assertEqual(data["args"], [1461196800000])
+        self.assertEqual(data["args"], ["2016-04-21"])
         client.close()
 
     def test_socket_options_contain_keepalive(self):
@@ -724,10 +724,10 @@ class TestUsernameSentAsHeader(TestingHttpServerTestCase):
 class TestCrateJsonEncoder(TestCase):
     def test_naive_datetime(self):
         data = dt.datetime.fromisoformat("2023-06-26T09:24:00.123")
-        result = json.dumps(data, cls=CrateJsonEncoder)
-        self.assertEqual(result, "1687771440123")
+        result = json_dumps(data)
+        self.assertEqual(result, b'"2023-06-26T09:24:00.123000"')
 
     def test_aware_datetime(self):
         data = dt.datetime.fromisoformat("2023-06-26T09:24:00.123+02:00")
-        result = json.dumps(data, cls=CrateJsonEncoder)
-        self.assertEqual(result, "1687764240123")
+        result = json_dumps(data)
+        self.assertEqual(result, b'"2023-06-26T09:24:00.123000+02:00"')


### PR DESCRIPTION
## About
Using [orjson](https://pypi.org/project/orjson/) for JSON marshalling can yield performance wins. It has been used in CrateDB Toolkit already, in that case its sister library [orjsonl](https://pypi.org/project/orjsonl/). Thanks, @widmogrod.

## References
- GH-689
- https://github.com/crate/cratedb-toolkit/pull/270

## Downstream
- https://github.com/crate/crash/pull/459
- https://github.com/crate/cratedb-toolkit/pull/349
- https://github.com/crate/cratedb-examples/pull/811
- https://github.com/crate/sqlalchemy-cratedb/pull/195
- https://github.com/crate/langchain-cratedb/pull/23
- https://github.com/crate/academy-fundamentals-course/pull/49
- https://github.com/crate/cloud-api/pull/3038
- https://github.com/crate/stevedore/pull/325
- https://github.com/crate/grand-central/pull/189
