### PR TITLE
Marshalling: Disable option `orjson.OPT_PASSTHROUGH_DATETIME`

### DIFF
--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -20,7 +20,6 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 
-import calendar
 import heapq
 import io
 import logging
@@ -30,11 +29,10 @@ import socket
 import ssl
 import threading
 from base64 import b64encode
-from datetime import date, datetime, timezone
+from datetime import datetime, timezone
 from decimal import Decimal
 from time import time
 from urllib.parse import urlparse
-from uuid import UUID
 
 import orjson
 import urllib3

--- a/src/crate/client/http.py
+++ b/src/crate/client/http.py
@@ -95,21 +95,9 @@ def cratedb_json_encoder(obj):
     Encoder function for orjson.
 
     https://github.com/ijl/orjson#default
-    https://github.com/ijl/orjson#opt_passthrough_datetime
     """
-    if isinstance(obj, (Decimal, UUID)):
+    if isinstance(obj, (Decimal,)):
         return str(obj)
-    if isinstance(obj, datetime):
-        if obj.tzinfo is not None:
-            delta = obj - epoch_aware
-        else:
-            delta = obj - epoch_naive
-        return int(
-            delta.microseconds / 1000.0
-            + (delta.seconds + delta.days * 24 * 3600) * 1000.0
-        )
-    if isinstance(obj, date):
-        return calendar.timegm(obj.timetuple()) * 1000
     return obj
 
 
@@ -117,7 +105,7 @@ def json_dumps(obj):
     return orjson.dumps(
         obj,
         default=cratedb_json_encoder,
-        option=(orjson.OPT_PASSTHROUGH_DATETIME | orjson.OPT_SERIALIZE_NUMPY),
+        option=orjson.OPT_SERIALIZE_NUMPY,
     )
 
 

--- a/tests/client/test_http.py
+++ b/tests/client/test_http.py
@@ -318,7 +318,7 @@ class HttpClientTest(TestCase):
         # convert string to dict
         # because the order of the keys isn't deterministic
         data = json.loads(request.call_args[1]["data"])
-        self.assertEqual(data["args"], [1425108700000])
+        self.assertEqual(data["args"], ["2015-02-28T07:31:40"])
         client.close()
 
     @patch(REQUEST, autospec=True)
@@ -329,7 +329,7 @@ class HttpClientTest(TestCase):
         day = dt.date(2016, 4, 21)
         client.sql("insert into users (dt) values (?)", (day,))
         data = json.loads(request.call_args[1]["data"])
-        self.assertEqual(data["args"], [1461196800000])
+        self.assertEqual(data["args"], ["2016-04-21"])
         client.close()
 
     def test_socket_options_contain_keepalive(self):

--- a/tests/client/test_http.py
+++ b/tests/client/test_http.py
@@ -725,9 +725,9 @@ class TestCrateJsonEncoder(TestCase):
     def test_naive_datetime(self):
         data = dt.datetime.fromisoformat("2023-06-26T09:24:00.123")
         result = json_dumps(data)
-        self.assertEqual(result, b"1687771440123")
+        self.assertEqual(result, b'"2023-06-26T09:24:00.123000"')
 
     def test_aware_datetime(self):
         data = dt.datetime.fromisoformat("2023-06-26T09:24:00.123+02:00")
         result = json_dumps(data)
-        self.assertEqual(result, b"1687764240123")
+        self.assertEqual(result, b'"2023-06-26T09:24:00.123000+02:00"')


### PR DESCRIPTION
## About
Separately from https://github.com/crate/sqlalchemy-cratedb/pull/195, let's explore which changes are needed when disabling orjson's `OPT_PASSTHROUGH_DATETIME` option.
