### PR TITLE
Chore: Fix build wrt. `setuptools` and `urllib3`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 setuptools<80.3
+urllib3<2.4
 zc.buildout==3.3
 zope.interface==6.4.post2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+setuptools<80.3
 zc.buildout==3.3
 zope.interface==6.4.post2


### PR DESCRIPTION
## Problem I
```python
ModuleNotFoundError: No module named 'setuptools.package_index'
```
-- https://github.com/crate/crate-python/actions/runs/14850452065/job/41692926889#step:5:97

## Problem II
```python
SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: Missing Authority Key Identifier
```
- https://github.com/crate/crate-python/issues/708