### PR TITLE
CI: Use Python 3.13 for CodeQL analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,7 @@ jobs:
       fail-fast: false
       matrix:
         language: [ python ]
-        python-version: ['3.11']
+        python-version: ['3.13']
 
     steps:
       - name: Checkout


### PR DESCRIPTION
What the title says.