### PR TITLE
Remove python 3.7 and 3.8 from test matrix.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ['ubuntu-22.04']
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         cratedb-version: ['nightly']
 
         # To save resources, only verify the most recent Python versions on macOS.


### PR DESCRIPTION
As you may know, both 3.7 and 3.8 are EOL, they receive no support/security fixes, nothing.

For that reason I would propose to remove them from the test matrix, we are also seeing new dependencies updates fail on 3.7, because of the libraries using >3.7 syntax (walrus operator), an example of this is https://github.com/crate/crate-python/actions/runs/15392143903/job/43303839083

We previously had a discussion on whether or not to keep 3.8 at https://github.com/crate/cratedb-sqlparse/pull/173

## Summary of the changes / Why this is an improvement
- Title
