### PR TITLE
Increase wait time threshold for Crate instance startup

### DIFF
--- a/src/crate/testing/layer.py
+++ b/src/crate/testing/layer.py
@@ -387,7 +387,7 @@ class CrateLayer:
                 self.stop()
                 raise e
 
-            if wait_time > 30:
+            if wait_time > 60:
                 for line in line_buf.lines:
                     log.error(line)
                 self.stop()


### PR DESCRIPTION
Increased the wait time threshold from 30 to 60 seconds before raising an error.

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #734 
