### PR TITLE
Remove py < 3.9 deps; Mention dropped python version support in changes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,8 +4,11 @@ Changes for crate
 
 Unreleased
 ==========
-- Modernize project definition to latest Python best practices. Thanks, @surister.
-- Exceptions: Exceptions from the BLOB API now include their full names.
+
+- Exceptions from the BLOB API now include their full names.
+
+- Dropped support for Python versions earlier than 3.10 as they've reached
+  their end of life.
 
 2025/01/30 2.0.0
 ================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,6 @@ classifiers = [
         "Topic :: System :: Networking",
 ]
 dependencies = [
-    "importlib-metadata; python_version<'3.8'",
     "orjson",
     "urllib3",
     "verlib2>=0.3.1",
@@ -57,7 +56,6 @@ dependencies = [
 
 [dependency-groups]
 dev = [
-    "backports.zoneinfo<1; python_version<'3.9'",
     "certifi",
     "coverage",
     "mypy<1.20",

--- a/tests/client/test_cursor.py
+++ b/tests/client/test_cursor.py
@@ -20,22 +20,16 @@
 # software solely pursuant to the terms of the relevant commercial agreement.
 
 import datetime
+import zoneinfo
 from ipaddress import IPv4Address
 from unittest import mock
 
 import pytest
-
-from crate.client.exceptions import ProgrammingError
-
-try:
-    import zoneinfo
-except ImportError:
-    from backports import zoneinfo
-
 import pytz
 
 from crate.client import connect
 from crate.client.converter import DataType, DefaultTypeConverter
+from crate.client.exceptions import ProgrammingError
 
 
 def test_cursor_fetch(mocked_connection):


### PR DESCRIPTION
Also removes the "Modernize project definition" entry. CHANGES.rst
should be written for users of the library. The entry had no relevance
for end users.
