### PR TITLE
CI: Validate on free-threaded Python (GHA label `3.14t`)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,6 +34,7 @@ jobs:
           '3.12',
           '3.13',
           '3.14',
+          '3.14t',
         ]
 
         # To save resources, only verify other variants particularly.


### PR DESCRIPTION
Just maintenance.