### PR TITLE
Linter: Update to ruff 0.15.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ dev = [
     "mypy<1.20",
     "pytest<10",
     "pytz",
-    "ruff<0.15",
+    "ruff<0.16",
 ]
 docs = [
     "sphinx",

--- a/src/crate/client/cursor.py
+++ b/src/crate/client/cursor.py
@@ -193,7 +193,8 @@ class Cursor:
         else:
             raise ProgrammingError("Cursor closed")
 
-    __next__ = next
+    def __next__(self):
+        return self.next()
 
     @property
     def description(self):

--- a/tests/client/test_cursor.py
+++ b/tests/client/test_cursor.py
@@ -250,9 +250,9 @@ def test_execute_custom_converter(mocked_connection):
     # Extends the DefaultTypeConverter
     converter = DefaultTypeConverter(
         {
-            DataType.BIT: lambda value: value is not None
-            and int(value[2:-1], 2)
-            or None
+            DataType.BIT: lambda value: (
+                value is not None and int(value[2:-1], 2) or None
+            )
         }
     )
     cursor = mocked_connection.cursor(converter=converter)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -227,7 +227,6 @@ def doctest_node():
 
 
 class HttpsServer(HTTPServer):
-
     PORT = 65534
     HOST = "localhost"
     CERT_FILE = assets_path("pki/server_valid.pem")


### PR DESCRIPTION
## Problem
This unrelated patch just [failed CI](https://github.com/crate/crate-python/actions/runs/21880687585/job/63162009338?pr=773#step:5:11) because the ruff linter complained.

- GH-773

## Thoughts
~~I don't know why the CI run on that update by Dependabot succeeded.~~ I think the CI run on that update by Dependabot didn't run yesterday, because it was submitted at a time when GitHub had outages across the board.

- GH-775