### PR TITLE
CI: Harmonize `versioningit` with GHA `release` workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v7


### PR DESCRIPTION
## Before
```
Successfully built dist/crate-0.0.0+unknown.tar.gz
Successfully built dist/crate-0.0.0+unknown-py3-none-any.whl
```
-- https://github.com/crate/crate-python/actions/runs/21884349065/job/63175218059#step:4:1

## After
```
Successfully built dist/crate-2.0.0.post68+g3d5a325.tar.gz
Successfully built dist/crate-2.0.0.post68+g3d5a325-py3-none-any.whl
```
-- https://github.com/crate/crate-python/actions/runs/21884379547/job/63175325373?pr=779#step:4:1
