### PR TITLE
Revert "CI: Fix HTTP certificate error when requesting example.org from GHA

### DIFF
--- a/docs/by-example/http.rst
+++ b/docs/by-example/http.rst
@@ -216,11 +216,12 @@ please use the ``urllib3.Timeout`` object like:
 
 When connecting to non-CrateDB servers, the HttpClient will raise a ConnectionError like this:
 
-    >>> http_client = HttpClient(["https://httpbin.org/html"])
+    >>> http_client = HttpClient(["https://example.org/"])
     >>> http_client.server_infos(http_client._get_server())
     Traceback (most recent call last):
     ...
-    crate.client.exceptions.ProgrammingError: 404 Client Error: NOT FOUND
+    crate.client.exceptions.ProgrammingError: Invalid server response of content-type 'text/html':
+    ...
     >>> http_client.close()
 
 When using the ``error_trace`` kwarg a full traceback of the server exception


### PR DESCRIPTION
## About

@mfussenegger is right by [saying](https://github.com/crate/crate-python/pull/778#pullrequestreview-3783056072):

> Why change this? example.org is specifically for use in documentation examples.

This reverts commit f4af7613be0719ce421fea023d5ea5f4fe746f67.

## Details

eeb0a56dce9 was needed because CI/GHA [started failing on macOS](https://github.com/crate/crate-python/actions/runs/21882822361) when using more recent versions than Python 3.12. I also don't like the change: Maybe you have an idea how to solve it differently?

```
HTTPSConnectionPool(host='www.example.org', port=443): Max retries exceeded
[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1081)
```
-- [CI run #21882822361](https://github.com/crate/crate-python/actions/runs/21882822361/job/63169829494#step:7:571)