### PR TITLE
_NAMED_PARAM_RE regex silently drops pyformat placeholders

### DIFF
--- a/src/crate/client/cursor.py
+++ b/src/crate/client/cursor.py
@@ -26,7 +26,7 @@ from datetime import datetime, timedelta, timezone
 from .converter import Converter, DataType
 from .exceptions import ProgrammingError
 
-_NAMED_PARAM_RE = re.compile(r"%\((\w+)\)s")
+_NAMED_PARAM_RE = re.compile(r"%\(([^)]+)\)s")
 
 
 def _convert_named_to_positional(

--- a/tests/client/test_cursor.py
+++ b/tests/client/test_cursor.py
@@ -565,6 +565,24 @@ def test_execute_with_named_params_missing(mocked_connection):
     mocked_connection.client.sql.assert_not_called()
 
 
+def test_execute_with_named_params_non_identifier_keys(mocked_connection):
+    """
+    Verify that %(name)s placeholders whose name contains characters outside
+    [a-zA-Z0-9_] are still converted to positional $N markers.
+
+    """
+    cursor = mocked_connection.cursor()
+
+    cursor.execute(
+        "UPDATE characters SET data['x'] = %(data['x'])s WHERE name = %(name)s",
+        {"data['x']": 42, "name": "Berlin"},
+    )
+    sql, args, _ = mocked_connection.client.sql.call_args[0]
+    assert "%" not in sql
+    assert sql == "UPDATE characters SET data['x'] = $1 WHERE name = $2"
+    assert args == [42, "Berlin"]
+
+
 def test_cursor_close(mocked_connection):
     """
     Verify that a cursor is not closed if not specifically closed.


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
- Regex changed
- Added test

## Checklist

 - [x] Link to issue this PR refers to (if applicable): Fixes #808 
 - [x]  Improve test coverage
