### PR TITLE
Update Codecov action to version 7

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -21,7 +21,7 @@ permissions:
 jobs:
   documentation:
 
-    name: Run link checker
+    name: Build docs
     runs-on: ubuntu-latest
 
     steps:
@@ -44,4 +44,4 @@ jobs:
 
       - name: Build docs
         run: |
-          cd docs && make check
+          cd docs && make html

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,7 +77,7 @@ jobs:
           coverage xml
 
       - name: Upload coverage results to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v7
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:


### PR DESCRIPTION
## Summary of the changes / Why this is an improvement
Codecov is failing because of deprecated API url. This fix update Codecov action to version 7

https://github.com/codecov/codecov-action#v7-release

## Checklist

 - [ ] Link to issue this PR refers to (if applicable): Fixes #???
