### PR TITLE
increasing max startup time for crate from 60s to 90s

### DIFF
--- a/src/crate/testing/layer.py
+++ b/src/crate/testing/layer.py
@@ -390,7 +390,7 @@ class CrateLayer:
                 self.stop()
                 raise e
 
-            if wait_time > 60:
+            if wait_time > 90:
                 for line in line_buf.lines:
                     log.error(line)
                 self.stop()


### PR DESCRIPTION
looks like it's all about this timeout, which was increased before from 30 to 60
I want to give 90 seconds a try, and hopefully this will rid us of the flaky tests

closes #805